### PR TITLE
[MWPW-156720] Send finalAssetId when only remove background operation is performed

### DIFF
--- a/unitylibs/core/workflow/workflow-photoshop/workflow-photoshop.js
+++ b/unitylibs/core/workflow/workflow-photoshop/workflow-photoshop.js
@@ -185,9 +185,9 @@ async function removeBgHandler(cfg, changeDisplay = true) {
   }
   const { outputUrl } = await response.json();
   const opId = new URL(outputUrl).pathname.split('/').pop();
+  cfg.preludeState.finalAssetId = opId;
   cfg.presentState.removeBgState.assetId = opId;
   cfg.presentState.removeBgState.assetUrl = outputUrl;
-  cfg.preludeState.finalAssetId = opId;
   cfg.preludeState.operations.push({ name: 'removeBackground' });
   if (!changeDisplay) return true;
   await updateImgClasses(cfg, img);


### PR DESCRIPTION
* Send finalAssetId when only remove background operation is performed

Resolves: [MWPW-156720](https://jira.corp.adobe.com/browse/MWPW-156720)

**Test URLs:**
- Before: https://stage--unity--adobecom.hlx.page/drafts/ruchika/remove-background?martech=off
- After: https://finalassetid--unity--adobecom.hlx.page/drafts/ruchika/remove-background?martech=off