### PR TITLE
[MWPW-156874] Throw error when image greater than 4K

### DIFF
--- a/unitylibs/core/steps/upload-btn.js
+++ b/unitylibs/core/steps/upload-btn.js
@@ -46,7 +46,7 @@ export default async function createUpload(cfg, target, callback = null) {
     target.src = objUrl;
     target.onload = async () => {
       // Throw error if uploaded image is greater than 4K
-      if (target.naturalWidth > 3840 && target.naturalHeight > 2160) {
+      if (target.naturalWidth > 4000 && target.naturalHeight > 4000) {
         await showErrorToast(targetEl, unityEl, '.icon-error-filetype');
         return;
       }

--- a/unitylibs/core/steps/upload-btn.js
+++ b/unitylibs/core/steps/upload-btn.js
@@ -46,7 +46,7 @@ export default async function createUpload(cfg, target, callback = null) {
     target.src = objUrl;
     target.onload = async () => {
       // Throw error if uploaded image is greater than 4K
-      if (target.naturalWidth > 4000 || target.naturalHeight > 4000) {
+      if (target.naturalWidth > 8000 || target.naturalHeight > 8000) {
         await showErrorToast(targetEl, unityEl, '.icon-error-filetype');
         return;
       }

--- a/unitylibs/core/steps/upload-btn.js
+++ b/unitylibs/core/steps/upload-btn.js
@@ -45,7 +45,6 @@ export default async function createUpload(cfg, target, callback = null) {
     resetClasses(target, targetEl);
     target.src = objUrl;
     target.onload = async () => {
-      // Throw error if uploaded image is greater than 4K
       if (target.naturalWidth > 8000 || target.naturalHeight > 8000) {
         await showErrorToast(targetEl, unityEl, '.icon-error-filetype');
         return;

--- a/unitylibs/core/steps/upload-btn.js
+++ b/unitylibs/core/steps/upload-btn.js
@@ -46,7 +46,7 @@ export default async function createUpload(cfg, target, callback = null) {
     target.src = objUrl;
     target.onload = async () => {
       // Throw error if uploaded image is greater than 4K
-      if (target.naturalWidth > 4000 && target.naturalHeight > 4000) {
+      if (target.naturalWidth > 4000 || target.naturalHeight > 4000) {
         await showErrorToast(targetEl, unityEl, '.icon-error-filetype');
         return;
       }

--- a/unitylibs/core/steps/upload-btn.js
+++ b/unitylibs/core/steps/upload-btn.js
@@ -45,6 +45,11 @@ export default async function createUpload(cfg, target, callback = null) {
     resetClasses(target, targetEl);
     target.src = objUrl;
     target.onload = async () => {
+      // Throw error if uploaded image is greater than 4K
+      if (target.naturalWidth > 3840 && target.naturalHeight > 2160) {
+        await showErrorToast(targetEl, unityEl, '.icon-error-filetype');
+        return;
+      }
       cfg.uploadState.filetype = file.type;
       cfg.isUpload = true;
       if (callback && flag) {

--- a/unitylibs/core/styles/styles.css
+++ b/unitylibs/core/styles/styles.css
@@ -704,6 +704,10 @@
     object-position: center;
   }
 
+  .marquee.split.unity-enabled .asset.bleed .interactive-area > picture img {
+    min-height: unset;
+  }
+
   .unity-enabled .interactive-area .unity-widget {
     bottom: 63px;
     margin-left: auto;


### PR DESCRIPTION
* Throw error when image greater than 4K

Resolves: [MWPW-156874](https://jira.corp.adobe.com/browse/MWPW-156874)

**Test URLs:**
- Before: https://stage--unity--adobecom.hlx.page/drafts/ruchika/remove-background?martech=off
- After: https://image-dimension--unity--adobecom.hlx.page/drafts/ruchika/remove-background?martech=off

**Note:** Showing same error message as of now that is shown for file type as Jessica had mentioned in this ticket https://jira.corp.adobe.com/browse/MWPW-156605
<img width="698" alt="Screen Shot 2024-08-19 at 11 49 52 AM" src="https://github.com/user-attachments/assets/c8c173f4-fc3a-4702-9416-1b7894445fee">
However we might need to discuss the error message with Jessica once.

