### PR TITLE
Performance improvements

### DIFF
--- a/unitylibs/blocks/unity/unity.js
+++ b/unitylibs/blocks/unity/unity.js
@@ -37,6 +37,7 @@ export default async function init(el) {
   const [{ default: wfinit }, { default: productWfInit }] = await Promise.all([
     import(`${unitylibs}/core/workflow/workflow.js`),
     import(`${unitylibs}/core/workflow/${wfName}/${wfName}.js`),
+    import(`${unitylibs}/scripts/utils.js`),
     new Promise((resolve) => {
       loadStyle(`${unitylibs}/core/styles/styles.css`, resolve);
     }),
@@ -45,7 +46,6 @@ export default async function init(el) {
     }),
     import(`${unitylibs}/core/steps/app-connector.js`),
     import(`${unitylibs}/core/steps/upload-btn.js`),
-    import(`${unitylibs}/core/workflow/${wfName}/${wfName}.js`),
   ]);
   await wfinit({
     el, projectName, unitylibs, wfName, wfDetail, productWfInit,

--- a/unitylibs/blocks/unity/unity.js
+++ b/unitylibs/blocks/unity/unity.js
@@ -19,10 +19,11 @@ function getUnityLibs(prodLibs, project = 'unity') {
 export default async function init(el) {
   const projectName = 'unity';
   const unitylibs = getUnityLibs('/unitylibs', projectName);
-  const stylePromise = new Promise((resolve) => {
-    loadStyle(`${unitylibs}/core/styles/styles.css`, resolve);
-  });
-  await stylePromise;
-  const { default: wfinit } = await import(`${unitylibs}/core/workflow/workflow.js`);
+  const [{ default: wfinit }] = await Promise.all([
+    import(`${unitylibs}/core/workflow/workflow.js`),
+    new Promise((resolve) => {
+      loadStyle(`${unitylibs}/core/styles/styles.css`, resolve);
+    }),
+  ]);
   await wfinit(el, projectName, unitylibs);
 }

--- a/unitylibs/blocks/unity/unity.js
+++ b/unitylibs/blocks/unity/unity.js
@@ -44,6 +44,7 @@ export default async function init(el) {
       loadStyle(`${getUnityLibs()}/core/workflow/${wfName}/${wfName}.css`, resolve);
     }),
     import(`${unitylibs}/core/steps/app-connector.js`),
+    import(`${unitylibs}/core/steps/upload-btn.js`),
     import(`${unitylibs}/core/workflow/${wfName}/${wfName}.js`),
   ]);
   await wfinit({

--- a/unitylibs/core/steps/app-connector.js
+++ b/unitylibs/core/steps/app-connector.js
@@ -21,7 +21,7 @@ function getPreludeData(cfg) {
   return dataObj;
 }
 
-async function continueInApp(cfg, appName, btnConfig) {
+async function continueInApp(cfg, appName, btnCfg, preloadedSvgs) {
   const {
     apiKey,
     connectorApiEndPoint,
@@ -32,7 +32,13 @@ async function continueInApp(cfg, appName, btnConfig) {
   } = cfg;
   const continuebtn = unityWidget.querySelector(`continue-in-${appName}`);
   if (continuebtn) return continuebtn;
-  const btn = await createActionBtn(btnConfig, `continue-in-app continue-in-${appName}`, true, true);
+  const btn = await createActionBtn({
+    btnCfg,
+    btnClass: `continue-in-app continue-in-${appName}`,
+    iconAsImg: true,
+    swapOrder: true,
+    preloadedSvgs,
+  });
   btn.addEventListener('click', async (evt) => {
     evt.preventDefault();
     const { showErrorToast } = await import('../../scripts/utils.js');
@@ -65,12 +71,12 @@ function resetAppConnector(cfg) {
   connectBtn?.classList.remove('show');
 }
 
-export default async function initAppConnector(cfg, appName) {
+export default async function initAppConnector(cfg, appName, preloadedSvgs) {
   const { unityEl, unityWidget, refreshWidgetEvent, interactiveSwitchEvent, targetEl } = cfg;
   const isContinueEnabled = unityEl.querySelector('.icon-app-connector');
   if (!isContinueEnabled) return;
   const btnConfig = isContinueEnabled.closest('li');
-  const connectBtn = await continueInApp(cfg, appName, btnConfig);
+  const connectBtn = await continueInApp(cfg, appName, btnConfig, preloadedSvgs);
   unityWidget.querySelector('.unity-action-area').append(connectBtn);
   unityEl.addEventListener(refreshWidgetEvent, () => {
     connectBtn?.classList.remove('show');

--- a/unitylibs/core/steps/upload-btn.js
+++ b/unitylibs/core/steps/upload-btn.js
@@ -17,10 +17,10 @@ export function resetClasses(img, targetEl) {
   if (targetEl.classList.contains(GRAY_BG)) targetEl.classList.remove(GRAY_BG);
 }
 
-export default async function createUpload(cfg, target, callback = null) {
+export default async function createUpload(cfg, target, callback = null, preloadedSvgs) {
   const { refreshWidgetEvent, targetEl, unityEl } = cfg;
   const li = unityEl.querySelector('.icon-upload').parentElement;
-  const a = await createActionBtn(li, 'show');
+  const a = await createActionBtn({ btnCfg: li, btnClass: 'show', preloadedSvgs });
   const input = createTag('input', { class: 'file-upload', type: 'file', accept: 'image/png,image/jpg,image/jpeg', tabIndex: -1 });
   a.append(input);
   a.addEventListener('keydown', (e) => {
@@ -60,9 +60,9 @@ export default async function createUpload(cfg, target, callback = null) {
           }
           if (!targetEl.classList.contains(GRAY_BG)) targetEl.classList.add(GRAY_BG);
           if (target.naturalWidth > targetElWidth) {
-              cfg.imgDisplay = 'landscape';
-              if (!target.classList.contains(IMG_LANDSCAPE)) target.classList.add(IMG_LANDSCAPE);
-              if (target.classList.contains(FULL_HEIGHT)) target.classList.remove(FULL_HEIGHT);
+            cfg.imgDisplay = 'landscape';
+            if (!target.classList.contains(IMG_LANDSCAPE)) target.classList.add(IMG_LANDSCAPE);
+            if (target.classList.contains(FULL_HEIGHT)) target.classList.remove(FULL_HEIGHT);
           } else {
             cfg.imgDisplay = 'portrait';
             if (!target.classList.contains(IMG_PORTRAIT)) target.classList.add(IMG_PORTRAIT);

--- a/unitylibs/core/styles/styles.css
+++ b/unitylibs/core/styles/styles.css
@@ -704,6 +704,10 @@
     object-position: center;
   }
 
+  .marquee.split.unity-enabled .asset.bleed .interactive-area > picture img {
+    min-height: unset;
+  }
+
   .unity-enabled .interactive-area .unity-widget {
     bottom: 63px;
     margin-left: auto;

--- a/unitylibs/core/workflow/workflow-photoshop/workflow-photoshop.js
+++ b/unitylibs/core/workflow/workflow-photoshop/workflow-photoshop.js
@@ -484,13 +484,15 @@ async function uploadCallback(cfg) {
 export default async function init(cfg) {
   const { targetEl, unityEl, unityWidget, interactiveSwitchEvent, refreshWidgetEvent } = cfg;
   resetWorkflowState(cfg);
-  await addProductIcon(cfg);
-  await changeVisibleFeature(cfg);
   const img = cfg.targetEl.querySelector('picture img');
-  const uploadBtn = await createUpload(cfg, img, uploadCallback);
+  const [uploadBtn] = await Promise.all([
+    createUpload(cfg, img, uploadCallback),
+    addProductIcon(cfg),
+    changeVisibleFeature(cfg),
+    initAppConnector(cfg, 'photoshop'),
+    decorateDefaultLinkAnalytics(unityWidget),
+  ]);
   unityWidget.querySelector('.unity-action-area').append(uploadBtn);
-  await initAppConnector(cfg, 'photoshop');
-  await decorateDefaultLinkAnalytics(unityWidget);
   unityEl.addEventListener(interactiveSwitchEvent, async () => {
     await changeVisibleFeature(cfg);
     await switchProdIcon(cfg, false);

--- a/unitylibs/core/workflow/workflow-photoshop/workflow-photoshop.js
+++ b/unitylibs/core/workflow/workflow-photoshop/workflow-photoshop.js
@@ -8,6 +8,14 @@ import {
   decorateDefaultLinkAnalytics,
   createIntersectionObserver,
 } from '../../../scripts/utils.js';
+import {
+  IMG_LANDSCAPE,
+  IMG_PORTRAIT,
+  IMG_REMOVE_BG,
+  resetClasses,
+  default as createUpload,
+} from '../../steps/upload-btn.js';
+import initAppConnector from '../../steps/app-connector.js';
 
 function resetSliders(unityWidget) {
   const adjustmentCircles = unityWidget.querySelectorAll('.adjustment-circle');
@@ -89,11 +97,6 @@ async function handleEvent(cfg, eventHandler) {
 async function updateImgClasses(cfg, img) {
   const { imgDisplay } = cfg;
   if (imgDisplay === 'landscape' || imgDisplay === 'portrait') {
-    const {
-      IMG_LANDSCAPE,
-      IMG_PORTRAIT,
-      IMG_REMOVE_BG,
-    } = await import('../../steps/upload-btn.js');
     if (cfg.imgDisplay === 'landscape') {
       if (img.classList.contains(IMG_LANDSCAPE)) img.classList.remove(IMG_LANDSCAPE);
     } else if (cfg.imgDisplay === 'portrait') {
@@ -452,7 +455,6 @@ async function resetWidgetState(cfg) {
   unityWidget.querySelector('.widget-product-icon')?.classList.add('show');
   unityWidget.querySelector('.widget-refresh-button').classList.remove('show');
   targetEl.querySelector(':scope > .widget-refresh-button').classList.remove('show');
-  const { resetClasses } = await import('../../steps/upload-btn.js');
   resetClasses(img, targetEl);
   resetSliders(unityWidget);
   await loadImg(img);
@@ -485,10 +487,8 @@ export default async function init(cfg) {
   await addProductIcon(cfg);
   await changeVisibleFeature(cfg);
   const img = cfg.targetEl.querySelector('picture img');
-  const { default: createUpload } = await import('../../steps/upload-btn.js');
   const uploadBtn = await createUpload(cfg, img, uploadCallback);
   unityWidget.querySelector('.unity-action-area').append(uploadBtn);
-  const { default: initAppConnector } = await import('../../steps/app-connector.js');
   await initAppConnector(cfg, 'photoshop');
   await decorateDefaultLinkAnalytics(unityWidget);
   unityEl.addEventListener(interactiveSwitchEvent, async () => {

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -83,7 +83,18 @@ export function loadImg(img) {
   });
 }
 
-export async function createActionBtn(btnCfg, btnClass, iconAsImg = false, swapOrder = false) {
+function svgToDataUrl(svg) {
+  const svgBlob = new Blob([svg], { type: 'image/svg+xml' });
+  return URL.createObjectURL(svgBlob);
+}
+
+export async function createActionBtn({
+  btnCfg,
+  btnClass,
+  iconAsImg = false,
+  swapOrder = false,
+  preloadedSvgs = {},
+} = {}) {
   const txt = btnCfg.innerText;
   const img = btnCfg.querySelector('img[src*=".svg"]');
   const actionBtn = createTag('a', { href: '#', class: `unity-action-btn ${btnClass}` });
@@ -91,8 +102,9 @@ export async function createActionBtn(btnCfg, btnClass, iconAsImg = false, swapO
     let btnImg = null;
     const { pathname } = new URL(img.src);
     const libSrcPath = `${getUnityLibs().split('/unitylibs')[0]}${pathname}`;
-    if (iconAsImg) btnImg = createTag('img', { src: libSrcPath });
-    else btnImg = await loadSvg(libSrcPath);
+    const preloadedSvg = await preloadedSvgs[img.src];
+    if (iconAsImg) btnImg = preloadedSvg ? createTag('img', { src: svgToDataUrl(preloadedSvg) }) : createTag('img', { src: libSrcPath });
+    else btnImg = await preloadedSvg || await loadSvg(libSrcPath);
     const btnIcon = createTag('div', { class: 'btn-icon' }, btnImg);
     actionBtn.append(btnIcon);
   }


### PR DESCRIPTION
There are a few discussions about [preloading](https://github.com/orgs/adobecom/discussions/2719), as well as after this initial research, I'll open a discussion based on the advantages of parallelizing loading.

As project unity will only display POST-LCP, we can parallelize as much as the browser allows us to do, as we will need the assets anyway. I tried to keep this PR "unintrusive" by not changing any order of JS operations and simply moving a few imports and loading actions around.

### Observable improvements:
I've used local overwrites to test this on the prod pages behind akamai:
- Prod before, desktop: 1.73s
- Prod after, desktop: 1.31s

- Prod before, fast 4G (mobile): 3.34s
- Prod after, fast 4G (mobile) 2.13s

There is a bit of jitter within this data, but there should be general improvements. I'd love to see us observing the improvements using [CRUM](https://adobe-mwp.slack.com/archives/C06FV8K0PH8/p1723851457534279) and collect valuable data about this use-case. Numbers tested locally are usually _optimistic_ (e.g. 1.73s or 1.31s both sound too good for desktop) - so I'd love to follow those numbers.


### Future enhancement suggestions
- Method 1: Load a "facade" of the project unity so you don't even need most the logic components, JS, SVGs, CSS until _after_ the LCP and the base buttons will do.
- Method 2: Load project unity **after** the LCP (this might need some styling changes to reserve the necessary space to avoid CLS)

The general aim here is, we want to show the marquee (or any) image as fast as we can. Everything that is not part of the LCP block // image can be delayed. The user will not _instantly_ click the buttons within the marquee and even if an event listener to detect the click and loading the rest of the logic is good enough (gnav does that)

### Deep dive into what changed

Let’s establish the baseline, we queue a lot of imports. Each import // load needs to `(a)wait` for the response to be returned:
![1-combine-load-before](https://github.com/user-attachments/assets/92d59025-b185-45b5-bd06-66c5a78be988)

1 - We can combine loading styles & workflow:
![Screenshot 2024-08-17 at 07 46 42](https://github.com/user-attachments/assets/4a38787d-0f06-4cd0-b8f6-f043a12493ea)

2 - Move loading product workflow together with the base workflow 

![3-combine-load-workflows](https://github.com/user-attachments/assets/17deeafb-f7c2-44ae-b47c-50ac59182fb6)

3 - Require workflow step assets (upload-bin, app-connector) earlier within the product workflow, to start loading them whenever the product workflow has been loaded

![4-normal-import-for-required-assets](https://github.com/user-attachments/assets/75d5d2fa-5567-41d1-a23a-d63e4a4a9b2d)

4 - Loading all assets (svgs) concurrently and re-use them. IMO We can be even smarter here in the future by only loading the SVGs that are initially visible, we might end up loading too much. But this PR should serve as a good inspiration and good first batch of improvements.

![5-parallelize-PS-WF](https://github.com/user-attachments/assets/304276a1-5567-44bc-8028-ef22809c3f7d)



**Test URLs:**
- Before: https://stage--unity--adobecom.hlx.page/drafts/ruchika/remove-background?martech=off
- After: https://perf-improvements--unity--adobecom.hlx.page/drafts/ruchika/remove-background?martech=off