### PR TITLE
MWPW-159953 | Bring splash screen above jarvis chat

### DIFF
--- a/unitylibs/core/styles/splash-screen.css
+++ b/unitylibs/core/styles/splash-screen.css
@@ -1,5 +1,5 @@
 body > .splash-loader {
-  z-index: 11;
+  z-index: 10000000;
 }
 
 .splash-loader {

--- a/unitylibs/core/styles/splash-screen.css
+++ b/unitylibs/core/styles/splash-screen.css
@@ -1,4 +1,8 @@
 body > .splash-loader {
+  z-index: 11;
+}
+
+body > .splash-loader.has-jarvis {
   z-index: 10000000;
 }
 

--- a/unitylibs/core/styles/splash-screen.css
+++ b/unitylibs/core/styles/splash-screen.css
@@ -1,8 +1,4 @@
 body > .splash-loader {
-  z-index: 11;
-}
-
-body > .splash-loader.has-jarvis {
   z-index: 10000000;
 }
 

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -272,6 +272,7 @@ export default class ActionBinder {
     const doc = new DOMParser().parseFromString(html, 'text/html');
     const sections = doc.querySelectorAll('body > div');
     const f = createTag('div', { class: 'fragment splash-loader decorate', style: 'display: none' });
+    if (document.querySelector('meta[name="jarvis-chat"]')) f.classList.add('has-jarvis');
     f.append(...sections);
     const splashDiv = document.querySelector(this.workflowCfg.targetCfg.splashScreenConfig.splashScreenParent);
     splashDiv.append(f);

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -272,7 +272,6 @@ export default class ActionBinder {
     const doc = new DOMParser().parseFromString(html, 'text/html');
     const sections = doc.querySelectorAll('body > div');
     const f = createTag('div', { class: 'fragment splash-loader decorate', style: 'display: none' });
-    if (document.querySelector('meta[name="jarvis-chat"]')) f.classList.add('has-jarvis');
     f.append(...sections);
     const splashDiv = document.querySelector(this.workflowCfg.targetCfg.splashScreenConfig.splashScreenParent);
     splashDiv.append(f);

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -226,16 +226,16 @@ export default class ActionBinder {
         { body: JSON.stringify(cOpts) },
       ),
     );
-    await Promise.all(this.promiseStack)
-      .then((resArr) => {
-        const response = resArr[resArr.length - 1];
-        if (!response?.url) throw new Error('Error connecting to App');
-        window.location.href = response.url;
-      })
-      .catch(async (e) => {
-        await this.showSplashScreen();
-        await this.dispatchErrorToast('verb_upload_error_generic');
-      });
+    // await Promise.all(this.promiseStack)
+    //   .then((resArr) => {
+    //     const response = resArr[resArr.length - 1];
+    //     if (!response?.url) throw new Error('Error connecting to App');
+    //     window.location.href = response.url;
+    //   })
+    //   .catch(async (e) => {
+    //     await this.showSplashScreen();
+    //     await this.dispatchErrorToast('verb_upload_error_generic');
+    //   });
   }
 
   async cancelAcrobatOperation() {

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -226,16 +226,16 @@ export default class ActionBinder {
         { body: JSON.stringify(cOpts) },
       ),
     );
-    // await Promise.all(this.promiseStack)
-    //   .then((resArr) => {
-    //     const response = resArr[resArr.length - 1];
-    //     if (!response?.url) throw new Error('Error connecting to App');
-    //     window.location.href = response.url;
-    //   })
-    //   .catch(async (e) => {
-    //     await this.showSplashScreen();
-    //     await this.dispatchErrorToast('verb_upload_error_generic');
-    //   });
+    await Promise.all(this.promiseStack)
+      .then((resArr) => {
+        const response = resArr[resArr.length - 1];
+        if (!response?.url) throw new Error('Error connecting to App');
+        window.location.href = response.url;
+      })
+      .catch(async (e) => {
+        await this.showSplashScreen();
+        await this.dispatchErrorToast('verb_upload_error_generic');
+      });
   }
 
   async cancelAcrobatOperation() {


### PR DESCRIPTION
Splash screen is not over the jarvis chat if same is enabled on the page. Increasing the z-index to be over jarvis.

Resolves: [MWPW-159953](https://jira.corp.adobe.com/browse/MWPW-159953)

Before: https://stage--dc--adobecom.hlx.page/acrobat/online/test/sign-pdf?martech=off
After: https://stage--dc--adobecom.hlx.page/acrobat/online/test/sign-pdf?martech=off&unitylibs=MWPW-159953