### PR TITLE
MWPW-160894 Increasing finalize timeout to 80 seconds

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -326,7 +326,7 @@ export default class ActionBinder {
       };
       const finalizeJson = await this.serviceHandler.postCallToService(
         this.acrobatApiConfig.acrobatEndpoint.finalizeAsset,
-        { body: JSON.stringify(finalAssetData), signal: AbortSignal.timeout?.(65000) },
+        { body: JSON.stringify(finalAssetData), signal: AbortSignal.timeout?.(80000) },
       );
       if (!finalizeJson || Object.keys(finalizeJson).length !== 0) {
         await this.showSplashScreen();

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -326,7 +326,7 @@ export default class ActionBinder {
       };
       const finalizeJson = await this.serviceHandler.postCallToService(
         this.acrobatApiConfig.acrobatEndpoint.finalizeAsset,
-        { body: JSON.stringify(finalAssetData) },
+        { body: JSON.stringify(finalAssetData), signal: AbortSignal.timeout?.(65000) },
       );
       if (!finalizeJson || Object.keys(finalizeJson).length !== 0) {
         await this.showSplashScreen();

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -326,7 +326,7 @@ export default class ActionBinder {
       };
       const finalizeJson = await this.serviceHandler.postCallToService(
         this.acrobatApiConfig.acrobatEndpoint.finalizeAsset,
-        { body: JSON.stringify(finalAssetData), signal: AbortSignal.timeout?.(15000)},
+        { body: JSON.stringify(finalAssetData) },
       );
       if (!finalizeJson || Object.keys(finalizeJson).length !== 0) {
         await this.showSplashScreen();


### PR DESCRIPTION
Increasing timeout for finalize API to 80 seconds to provide enough buffer for backend request.

Resolves: [MWPW-160894](https://jira.corp.adobe.com/browse/MWPW-160894)

Test URLs:

Before: https://stage--dc--adobecom.hlx.page/acrobat/online/test/sign-pdf?unitylibs=stage
After: https://stage--dc--adobecom.hlx.page/acrobat/online/test/sign-pdf?unitylibs=MWPW-160894