### PR TITLE
MWPW-159445-Remove thumbnail from authoring for change background in unity block for V2

### DIFF
--- a/unitylibs/core/workflow/workflow-photoshop/widget.js
+++ b/unitylibs/core/workflow/workflow-photoshop/widget.js
@@ -243,7 +243,7 @@ export default class UnityWidget {
     [...bgOptions].forEach((o, num) => {
       let thumbnail = null;
       let bgImg = null;
-      [bgImg] = o.querySelector('img');
+      bgImg = o.querySelector('img');
       thumbnail = bgImg;
       thumbnail.dataset.backgroundImg = bgImg.src;
       thumbnail.setAttribute('src', this.updateQueryParam(bgImg.src, { format: 'webply', width: '68', height: '68' }));

--- a/unitylibs/core/workflow/workflow-photoshop/widget.js
+++ b/unitylibs/core/workflow/workflow-photoshop/widget.js
@@ -2,6 +2,7 @@ import {
   createTag,
   decorateDefaultLinkAnalytics,
   loadSvgs,
+  priorityLoad,
 } from '../../../scripts/utils.js';
 
 export default class UnityWidget {
@@ -227,21 +228,33 @@ export default class UnityWidget {
     }
   }
 
+  updateQueryParam(url, params) {
+    const parsedUrl = new URL(url);
+    Object.entries(params).forEach(([key, value]) => {
+      parsedUrl.searchParams.set(key, value);
+    });
+    return parsedUrl;
+  }
+
   addChangeBgTray(btn, authCfg, optionArea, isVisible) {
     const bgSelectorTray = createTag('div', { class: `changebg-options-tray ${isVisible ? 'show' : ''}` });
     const bgOptions = authCfg.querySelectorAll(':scope ul li');
+    const thumbnailSrc = [];
     [...bgOptions].forEach((o, num) => {
       let thumbnail = null;
       let bgImg = null;
-      [thumbnail, bgImg] = o.querySelectorAll('img');
-      if (!bgImg) bgImg = thumbnail;
+      [bgImg] = o.querySelector('img');
+      thumbnail = bgImg;
       thumbnail.dataset.backgroundImg = bgImg.src;
+      thumbnail.setAttribute('src', this.updateQueryParam(bgImg.src, { format: 'webply', width: '68', height: '68' }));
+      thumbnailSrc.push(thumbnail.getAttribute('src'));
       const optionSelector = `changebg-option option-${num}`;
       const a = createTag('a', { href: '#', class: optionSelector }, thumbnail);
       bgSelectorTray.append(a);
       this.initChangeBgActions(`.changebg-option.option-${num}`, btn, bgImg, bgSelectorTray);
       a.addEventListener('click', (e) => { e.preventDefault(); });
     });
+    priorityLoad(thumbnailSrc);
     optionArea.append(bgSelectorTray);
     return bgSelectorTray;
   }


### PR DESCRIPTION
- Remove thumbnail from authoring for change background in unity block for V2
- This update is done to fix an issue with html localization flow https://github.com/adobe/helix-html2md/issues/555

Resolves: [MWPW-159445](https://jira.corp.adobe.com/browse/MWPW-159445)

Test URLs:

Before:
https://stage--unity--adobecom.hlx.page/drafts/ruchika/remove-background
After:
https://thumbnail-v2--unity--adobecom.hlx.page/drafts/ruchika/remove-background