### PR TITLE
MWPW-162832- Pass locale code to prelude

### DIFF
--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -68,7 +68,7 @@ export function getLocale() {
   const urlLocale = window.location.pathname.split('/')[1];
   const { locales } = getConfig();
   const locale = Object.entries(locales).find(([key]) => key === urlLocale);
-  return locale ? locale[1] : 'us';
+  return locale ? locale[0] : 'us';
 }
 
 export async function loadSvg(src) {

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -68,7 +68,7 @@ export function getLocale() {
   const urlLocale = window.location.pathname.split('/')[1];
   const { locales } = getConfig();
   const locale = Object.entries(locales).find(([key]) => key === urlLocale);
-  return locale ? locale[1].ietf : 'en-US';
+  return locale ? locale[1] : 'us';
 }
 
 export async function loadSvg(src) {

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -65,10 +65,8 @@ export function defineDeviceByScreenSize() {
 }
 
 export function getLocale() {
-  const urlLocale = window.location.pathname.split('/')[1];
-  const { locales } = getConfig();
-  const locale = Object.entries(locales).find(([key]) => key === urlLocale);
-  return locale ? locale[0] : 'us';
+  const currLocale = getConfig().locale?.prefix.replace('/', '')
+  return currLocale ? currLocale : 'us';
 }
 
 export async function loadSvg(src) {


### PR DESCRIPTION
- Pass locale code for locale mapping at prelude side

Resolves: [MWPW-162832](https://jira.corp.adobe.com/browse/MWPW-162832)

Test URLs:

Before: https://main--cc--adobecom.hlx.page/drafts/ruchika/remove-background1?unitylibs=stage
After: https://main--cc--adobecom.hlx.page/drafts/ruchika/remove-background1?unitylibs=locale-code

