### PR TITLE
MWPW-155682 Add dynamic import for errors.js

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -11,7 +11,6 @@ import {
   loadArea,
   loadImg,
 } from '../../../scripts/utils.js';
-import getError from '../../../scripts/errors.js';
 
 export default class ActionBinder {
   constructor(unityEl, workflowCfg, wfblock, canvasArea, actionMap = {}, limits = {}) {
@@ -159,7 +158,10 @@ export default class ActionBinder {
     if (showError) {
       const message = code in this.workflowCfg.errors
         ? this.workflowCfg.errors[code]
-        : await getError(this.workflowCfg.enabledFeatures[0], code);
+        : await (async () => {
+          const { getError } = await import('../../../scripts/errors.js');
+          return getError(this.workflowCfg.enabledFeatures[0], code);
+        })();
       this.block.dispatchEvent(new CustomEvent(
         unityConfig.errorToastEvent,
         {

--- a/unitylibs/scripts/errors.js
+++ b/unitylibs/scripts/errors.js
@@ -35,7 +35,7 @@ async function loadErrorMessages(verb) {
   window.uem = createErrorMap(errorJson?.data);
 }
 
-export default async function getError(verb, code) {
+export async function getError(verb, code) {
   try {
     if (!window.uem) await loadErrorMessages(verb);
     return window.uem?.[code];


### PR DESCRIPTION
[Performance Optimization] Adding dynamic import for getError method for dispatching errors.

Resolves: [MWPW-155682](https://jira.corp.adobe.com/browse/MWPW-155682)

Test URLs:

Before: https://stage--dc--adobecom.hlx.page/acrobat/online/test/sign-pdf?unitylibs=stage
After: https://stage--dc--adobecom.hlx.page/acrobat/online/test/sign-pdf?unitylibs=MWPW-155682-errors-import