### PR TITLE
[MWPW-159322] Reset on scroll

### DIFF
--- a/unitylibs/core/workflow/workflow-photoshop/action-binder.js
+++ b/unitylibs/core/workflow/workflow-photoshop/action-binder.js
@@ -129,6 +129,17 @@ export default class ActionBinder {
             e.preventDefault();
             await this.psActionMaps(values, e);
           });
+          if(values.find(v => v.actionType == 'refresh')) {
+            const observer = new IntersectionObserver((entries) => {
+              entries.forEach(async entry => {
+                if (!entry.isIntersecting) {
+                  await this.psActionMaps(values);
+                }
+              });
+            });
+          
+            observer.observe(this.canvasArea);
+          }
           break;
         case el.nodeName === 'INPUT':
           el.addEventListener('change', async (e) => {

--- a/unitylibs/core/workflow/workflow-photoshop/widget.js
+++ b/unitylibs/core/workflow/workflow-photoshop/widget.js
@@ -92,6 +92,20 @@ export default class UnityWidget {
         mobileRefreshHolder.classList.remove('show');
       });
     });
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (!entry.isIntersecting) {
+          this.target.querySelector('img').style.filter = '';
+          iconHolder.classList.add('show');
+          refreshHolder.classList.remove('show');
+          mobileRefreshHolder.classList.remove('show');
+        }
+      });
+    });
+  
+    observer.observe(this.target);
+
     this.initRefreshActionMap('.unity-action-area .widget-refresh-button');
     this.initRefreshActionMap('.interactive-area > .widget-refresh-button');
     unityaa.append(refreshHolder);


### PR DESCRIPTION
**Description:**
When user scrolls unity block out of the screen the unity image and widget will reset.

**Resolves:** [MWPW-159322](https://jira.corp.adobe.com/browse/MWPW-159322)

**Test URLs:**
Before: https://stage--unity--adobecom.hlx.page/drafts/rbogos/remove-background
After: https://mwpw-159322-reset-on-scroll--unity--adobecom.hlx.page/drafts/rbogos/remove-background
