### PR TITLE
MWPW-162758-Add cookie check for upload events

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -168,7 +168,7 @@ export default class ActionBinder {
         {
           detail: {
             code,
-            message: `${message || 'Unable to process the request'}`,
+            message: `${message}`,
             status,
             info,
             accountType: this.getAccountType(),

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -278,15 +278,11 @@ export default class ActionBinder {
         this.block.dispatchEvent(new CustomEvent(unityConfig.trackAnalyticsEvent, { detail: { event: 'redirect to product' } }));
         await this.waitForCookie(2000);
         this.updateProgressBar(this.splashScreenEl, 100);
-        if (this.checkCookie()) {
-          window.location.href = response.url;
-        }
-        else {
+        if (!this.checkCookie()) {
           await this.dispatchErrorToast('verb_cookie_not_set', 200, "Not all cookies found, redirecting anyway", true);
-          const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
-          await sleep(500);
-          window.location.href = response.url;
+          await new Promise(r => setTimeout(r, 500));
         }
+        window.location.href = response.url;
       })
       .catch(async (e) => {
         await this.showSplashScreen();

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -167,8 +167,8 @@ export default class ActionBinder {
         unityConfig.errorToastEvent,
         {
           detail: {
-            code, 
-            message: `${message || 'Unable to process the request'}`, 
+            code,
+            message: `${message || 'Unable to process the request'}`,
             status,
             info,
             accountType: this.getAccountType(),
@@ -225,7 +225,7 @@ export default class ActionBinder {
     await Promise.all(this.promiseStack);
   }
 
- checkCookie = () => {
+  checkCookie = () => {
     const cookies = document.cookie.split(';').map((item) => item.trim());
     const targets = [/^UTS_Uploading=/, /^UTS_Uploaded=/];
     return targets.every((regex) => cookies.some((item) => regex.test(item)));
@@ -275,7 +275,7 @@ export default class ActionBinder {
       .then(async (resArr) => {
         const response = resArr[resArr.length - 1];
         if (!response?.url) throw new Error('Error connecting to App');
-        this.block.dispatchEvent(new CustomEvent(unityConfig.trackAnalyticsEvent, { detail: { event: 'redirect to product' } }));        
+        this.block.dispatchEvent(new CustomEvent(unityConfig.trackAnalyticsEvent, { detail: { event: 'redirect to product' } }));
         await this.waitForCookie(2000);
         this.updateProgressBar(this.splashScreenEl, 100);
         if (this.checkCookie()) {
@@ -284,7 +284,7 @@ export default class ActionBinder {
         else {
           await this.dispatchErrorToast('verb_cookie_not_set', 200, "Not all cookies found, redirecting anyway", true);
           const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
-          await sleep(500); 
+          await sleep(500);
           window.location.href = response.url;
         }
       })


### PR DESCRIPTION
- Add cookie check for upload events before redirect

Resolves: [MWPW-162758](https://jira.corp.adobe.com/browse/MWPW-162758)

Test URLs:

Before: https://stage--cc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=stage
After: https://stage--cc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=analytics-cookie

Note: As the cookie is set only for adobe.com domain test by accessing above url on stage.adobe.com and overriding the action-binder.js with the code form this feature branch