### PR TITLE
MWPW-162758-Check only UTS_Uploaded cookie

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -227,8 +227,8 @@ export default class ActionBinder {
 
   checkCookie = () => {
     const cookies = document.cookie.split(';').map((item) => item.trim());
-    const targets = [/^UTS_Uploading=/, /^UTS_Uploaded=/];
-    return targets.every((regex) => cookies.some((item) => regex.test(item)));
+    const target = /^UTS_Uploaded=/;
+    return cookies.some((item) => target.test(item));
   };
 
   waitForCookie = (timeout) => {


### PR DESCRIPTION
- Check only UTS_Uploaded cookie

Resolves: [MWPW-162758](https://jira.corp.adobe.com/browse/MWPW-162758)

Test URLs:

Before: https://stage--cc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=stage
After: https://stage--cc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=cookie

Note: As the cookie is set only for adobe.com domain test by accessing above url on stage.adobe.com and overriding the action-binder.js with the code form this feature branch