### PR TITLE
MWPW-163260-Remove tooltip from Upload button

### DIFF
--- a/unitylibs/core/steps/upload-btn.js
+++ b/unitylibs/core/steps/upload-btn.js
@@ -23,10 +23,6 @@ export default async function createUpload(cfg, target, callback = null) {
   const a = await createActionBtn(li, 'show');
   const input = createTag('input', { class: 'file-upload', type: 'file', accept: 'image/png,image/jpg,image/jpeg', tabIndex: -1 });
   a.insertAdjacentElement('afterend', input);
-  a.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') input.click();
-  });
-  a.addEventListener('click', () => input.click()); 
   input.addEventListener('change', async (e) => {
     let flag = true;
     const fileUpload = e.target || input;
@@ -93,5 +89,9 @@ export default async function createUpload(cfg, target, callback = null) {
     };
     fileUpload.value = '';
   });
+  a.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') input.click();
+  });
+  a.addEventListener('click', () => input.click()); 
   return a;
 }

--- a/unitylibs/core/steps/upload-btn.js
+++ b/unitylibs/core/steps/upload-btn.js
@@ -29,9 +29,10 @@ export default async function createUpload(cfg, target, callback = null) {
   a.addEventListener('click', () => input.click()); 
   input.addEventListener('change', async (e) => {
     let flag = true;
+    const fileUpload = e.target || input;
     const { default: showProgressCircle } = await import('../features/progress-circle/progress-circle.js');
     const { showErrorToast } = await import('../../scripts/utils.js');
-    const file = e.target.files[0];
+    const file = fileUpload.files[0];
     if (!file) return;
     if (['image/jpeg', 'image/png', 'image/jpg'].indexOf(file.type) == -1) {
       await showErrorToast(targetEl, unityEl, '.icon-error-filetype');
@@ -90,7 +91,7 @@ export default async function createUpload(cfg, target, callback = null) {
     target.onerror = async () => {
       await showErrorToast(targetEl, unityEl, '.icon-error-request');
     };
-    e.target.value = '';
+    fileUpload.value = '';
   });
   return a;
 }

--- a/unitylibs/core/steps/upload-btn.js
+++ b/unitylibs/core/steps/upload-btn.js
@@ -26,9 +26,7 @@ export default async function createUpload(cfg, target, callback = null) {
   a.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') input.click();
   });
-  a.addEventListener('click', async (e) => {
-    input.click();
-  });  
+  a.addEventListener('click', () => input.click()); 
   input.addEventListener('change', async (e) => {
     let flag = true;
     const { default: showProgressCircle } = await import('../features/progress-circle/progress-circle.js');

--- a/unitylibs/core/steps/upload-btn.js
+++ b/unitylibs/core/steps/upload-btn.js
@@ -22,11 +22,14 @@ export default async function createUpload(cfg, target, callback = null) {
   const li = unityEl.querySelector('.icon-upload').parentElement;
   const a = await createActionBtn(li, 'show');
   const input = createTag('input', { class: 'file-upload', type: 'file', accept: 'image/png,image/jpg,image/jpeg', tabIndex: -1 });
-  a.append(input);
+  a.insertAdjacentElement('afterend', input);
   a.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') input.click();
   });
-  a.addEventListener('change', async (e) => {
+  a.addEventListener('click', async (e) => {
+    input.click();
+  });  
+  input.addEventListener('change', async (e) => {
     let flag = true;
     const { default: showProgressCircle } = await import('../features/progress-circle/progress-circle.js');
     const { showErrorToast } = await import('../../scripts/utils.js');

--- a/unitylibs/core/styles/styles.css
+++ b/unitylibs/core/styles/styles.css
@@ -116,7 +116,6 @@
 
 .unity-enabled .unity-action-btn .file-upload {
   display: none;
-  opacity: 0;
   position: absolute;
   z-index: 2;
   height: 100%;

--- a/unitylibs/core/styles/styles.css
+++ b/unitylibs/core/styles/styles.css
@@ -115,6 +115,7 @@
 }
 
 .unity-enabled .unity-action-btn .file-upload {
+  display: none;
   opacity: 0;
   position: absolute;
   z-index: 2;


### PR DESCRIPTION
- Remove default tooltip from Upload button that comes with file upload input element

Resolves: [MWPW-163260](https://jira.corp.adobe.com/browse/MWPW-163260)

Test URLs:

Before: https://stage--cc--adobecom.hlx.page/fr/products/photoshop/ai?unitylibs=stage&georouting=off
After: https://stage--cc--adobecom.hlx.page/fr/products/photoshop/ai?unitylibs=upload-tooltip&georouting=off
