### PR TITLE
MWPW-160906 | Border showing up on video on intermediate screen

### DIFF
--- a/unitylibs/core/styles/splash-screen.css
+++ b/unitylibs/core/styles/splash-screen.css
@@ -124,6 +124,9 @@ body > .splash-loader {
   border: none;
   outline: none;
   box-shadow: none;
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
+  -webkit-backface-visibility: hidden;
+  -moz-backface-visibility: hidden;
 }
 
 @media screen and (min-width: 600px) {


### PR DESCRIPTION
Fixing the issue where a ridge border is showing up for video tag.
Resolves : https://jira.corp.adobe.com/browse/MWPW-160906
