### PR TITLE
[Stage]MWPW-164631-Update splash screen as per the new design

### DIFF
--- a/unitylibs/core/styles/splash-screen.css
+++ b/unitylibs/core/styles/splash-screen.css
@@ -127,7 +127,20 @@ body > .splash-loader {
   -webkit-mask-image: -webkit-radial-gradient(white, black);
   -webkit-backface-visibility: hidden;
   -moz-backface-visibility: hidden;
+  width: 286px;
+  height: 230px;
 }
+
+.splash-loader .text h1:first-of-type,
+.splash-loader .text h2:first-of-type,
+.splash-loader .text h3:first-of-type,
+.splash-loader .text h4:first-of-type,
+.splash-loader .text h5:first-of-type,
+.splash-loader .text h6:first-of-type {
+  font-size: var(--type-heading-l-size);
+  line-height: var(--type-heading-l-lh);
+}
+
 
 @media screen and (min-width: 600px) {
   .splash-loader .text .icon-area img,

--- a/unitylibs/core/styles/splash-screen.css
+++ b/unitylibs/core/styles/splash-screen.css
@@ -127,8 +127,24 @@ body > .splash-loader {
   -webkit-mask-image: -webkit-radial-gradient(white, black);
   -webkit-backface-visibility: hidden;
   -moz-backface-visibility: hidden;
-  width: 286px;
-  height: 230px;
+}
+
+@media screen and (min-width: 600px) {
+  .splash-loader .text .icon-area img,
+  .splash-loader .text video {
+    width: 286px;
+    height: 230px;
+  }
+
+  .splash-loader h1,
+  .splash-loader h2,
+  .splash-loader h3,
+  .splash-loader h4,
+  .splash-loader h5 {
+    font-size: var(--type-heading-xl-size);
+    line-height: var(--type-heading-xl-lh);
+    font-weight: 700;
+  }
 }
 
 .splash-loader .text h1:first-of-type,
@@ -141,23 +157,8 @@ body > .splash-loader {
   line-height: var(--type-heading-l-lh);
 }
 
-
-@media screen and (min-width: 600px) {
-  .splash-loader .text .icon-area img,
-  .splash-loader .text video {
-    width: 286px;
-    height: auto;
-  }
-
-  .splash-loader h1,
-  .splash-loader h2,
-  .splash-loader h3,
-  .splash-loader h4,
-  .splash-loader h5 {
-    font-size: var(--type-heading-xl-size);
-    line-height: var(--type-heading-xl-lh);
-    font-weight: 700;
-  }
+.text-block [class^="heading"]:first-of-type {
+  margin: 0 0 var(--spacing-l) 0;
 }
 
 @media screen and (min-width: 1000px) {

--- a/unitylibs/core/styles/splash-screen.css
+++ b/unitylibs/core/styles/splash-screen.css
@@ -156,11 +156,11 @@ body > .splash-loader {
     line-height: var(--type-heading-l-lh);
   }
 
-  .text-block [class^="heading"]:first-of-type {
+  .splash-loader .text-block [class^="heading"]:first-of-type {
     margin: 0 0 var(--spacing-l) 0;
   }
   
-  .text-block p.icon-area {
+  .splash-loader .text-block p.icon-area {
     margin-block: var(--spacing-s);
   }
 }

--- a/unitylibs/core/styles/splash-screen.css
+++ b/unitylibs/core/styles/splash-screen.css
@@ -145,20 +145,24 @@ body > .splash-loader {
     line-height: var(--type-heading-xl-lh);
     font-weight: 700;
   }
-}
+  
+  .splash-loader .text h1:first-of-type,
+  .splash-loader .text h2:first-of-type,
+  .splash-loader .text h3:first-of-type,
+  .splash-loader .text h4:first-of-type,
+  .splash-loader .text h5:first-of-type,
+  .splash-loader .text h6:first-of-type {
+    font-size: var(--type-heading-l-size);
+    line-height: var(--type-heading-l-lh);
+  }
 
-.splash-loader .text h1:first-of-type,
-.splash-loader .text h2:first-of-type,
-.splash-loader .text h3:first-of-type,
-.splash-loader .text h4:first-of-type,
-.splash-loader .text h5:first-of-type,
-.splash-loader .text h6:first-of-type {
-  font-size: var(--type-heading-l-size);
-  line-height: var(--type-heading-l-lh);
-}
-
-.text-block [class^="heading"]:first-of-type {
-  margin: 0 0 var(--spacing-l) 0;
+  .text-block [class^="heading"]:first-of-type {
+    margin: 0 0 var(--spacing-l) 0;
+  }
+  
+  .text-block p.icon-area {
+    margin-block: var(--spacing-s);
+  }
 }
 
 @media screen and (min-width: 1000px) {

--- a/unitylibs/core/styles/splash-screen.css
+++ b/unitylibs/core/styles/splash-screen.css
@@ -150,8 +150,7 @@ body > .splash-loader {
   .splash-loader .text h2:first-of-type,
   .splash-loader .text h3:first-of-type,
   .splash-loader .text h4:first-of-type,
-  .splash-loader .text h5:first-of-type,
-  .splash-loader .text h6:first-of-type {
+  .splash-loader .text h5:first-of-type {
     font-size: var(--type-heading-l-size);
     line-height: var(--type-heading-l-lh);
   }

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -14,7 +14,7 @@
     },
     "showSplashScreen": true,
     "splashScreenConfig": {
-      "fragmentLink": "/drafts/ruchika/splashscreen",
+      "fragmentLink": "/dc-shared/fragments/shared-fragments/frictionless/splash-page/splashscreen",
       "splashScreenParent": "body"
     },
     "actionMap": {

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -14,7 +14,7 @@
     },
     "showSplashScreen": true,
     "splashScreenConfig": {
-      "fragmentLink": "/dc-shared/fragments/shared-fragments/frictionless/splash-page/splashscreen",
+      "fragmentLink": "/drafts/ruchika/splashscreen",
       "splashScreenParent": "body"
     },
     "actionMap": {


### PR DESCRIPTION
- This update is only for desktop to support already live Fill and Sign use case as F&S only has unity experience for Desktop only.
- Mobile design for splash screen will be handled as part of this ticket for Compress https://jira.corp.adobe.com/browse/MWPW-162586

Resolves: [MWPW-164631](https://jira.corp.adobe.com/browse/MWPW-164631)

Test URLs:

Before: https://stage--dc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=stage
After: https://stage--dc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=splash-desktop

Above url will not show the exact change as authoring updates have not been done. Changes can be tested here Test URLs:
https://stage--dc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=splash where an updated test fragment has been mapped.


**Note**: This PR needs to get merged along with authoring changes documented in the jira ticket.