### PR TITLE
[Main]MWPW-164631-Update splash screen as per the new design

### DIFF
--- a/unitylibs/core/styles/splash-screen.css
+++ b/unitylibs/core/styles/splash-screen.css
@@ -133,7 +133,7 @@ body > .splash-loader {
   .splash-loader .text .icon-area img,
   .splash-loader .text video {
     width: 286px;
-    height: auto;
+    height: 230px;
   }
 
   .splash-loader h1,
@@ -144,6 +144,23 @@ body > .splash-loader {
     font-size: var(--type-heading-xl-size);
     line-height: var(--type-heading-xl-lh);
     font-weight: 700;
+  }
+  
+  .splash-loader .text h1:first-of-type,
+  .splash-loader .text h2:first-of-type,
+  .splash-loader .text h3:first-of-type,
+  .splash-loader .text h4:first-of-type,
+  .splash-loader .text h5:first-of-type {
+    font-size: var(--type-heading-l-size);
+    line-height: var(--type-heading-l-lh);
+  }
+
+  .splash-loader .text-block [class^="heading"]:first-of-type {
+    margin: 0 0 var(--spacing-l) 0;
+  }
+  
+  .splash-loader .text-block p.icon-area {
+    margin-block: var(--spacing-s);
   }
 }
 
@@ -156,4 +173,3 @@ body > .splash-loader {
     min-width: 400px;
   }
 }
-


### PR DESCRIPTION
- This update is only for desktop to support already live Fill and Sign use case as F&S has unity experience for Desktop only.
- Mobile design for splash screen will be handled as part of this ticket for Compress https://jira.corp.adobe.com/browse/MWPW-162586

Resolves: [MWPW-164631](https://jira.corp.adobe.com/browse/MWPW-164631)

Test URLs:

Before: https://main--dc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=main
After: https://main--dc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=splash-main

Above url will not show the exact change as authoring updates have not been done. Changes can be tested here Test URLs:
https://main--dc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=splash where an updated test fragment has been mapped.


**Note**: This PR needs to get merged along with authoring changes documented in the jira ticket.