### PR TITLE
MWPW-163778 Including feedback value for signed-in single file nonPdf upload

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -568,6 +568,7 @@ export default class ActionBinder {
               type: file.type,
             },
           },
+          ...(isNonPdf ? { feedback: 'nonpdf' } : {}),
         },
       };
       await this.getRedirectUrl(cOpts);


### PR DESCRIPTION
Ensuring feedback value is included into connector payload for signed-in single file nonPdf upload

Resolves: [MWPW-163778](https://jira.corp.adobe.com/browse/MWPW-163778)

Test URLs:

Before: https://stage--dc--adobecom.hlx.page/acrobat/online/test/sign-pdf?unitylibs=stage
After: https://stage--dc--adobecom.hlx.page/acrobat/online/test/sign-pdf?unitylibs=MWPW-163778