### PR TITLE
MWPW-164846 Enable fetching of error JSON file to be environment-aware

### DIFF
--- a/unitylibs/scripts/errors.js
+++ b/unitylibs/scripts/errors.js
@@ -23,7 +23,10 @@ function createErrorMap(errorList) {
 
 async function loadErrorMessages(verb) {
   const { locale } = getConfig();
-  const baseUrl = 'https://main--unity--adobecom.hlx.live';
+  const { origin } = window.location;
+  const baseUrl = (origin.includes('hlx.page') || origin.includes('hlx.live')) 
+    ? 'https://main--unity--adobecom.hlx.live'
+    : origin;
   const errorFile = locale.prefix && locale.prefix !== '/'
     ? `${baseUrl}${locale.prefix}/unity/configs/errors/${verb}.json`
     : `${baseUrl}/unity/configs/errors/${verb}.json`;


### PR DESCRIPTION
Enable fetching of verb error JSON file to be environment-aware

Resolves: [MWPW-164846](https://jira.corp.adobe.com/browse/MWPW-164846)

Test URLs:

Before: https://stage--dc--adobecom.hlx.page/acrobat/online/test/compress-pdf?unitylibs=stage
After: https://stage--dc--adobecom.hlx.live/acrobat/online/test/compress-pdf?unitylibs=MWPW-164846