### PR TITLE
MWPW-163777 Updating allowed file types list for CPDF

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -49,13 +49,26 @@
       "allowedFileTypes": [
         "application/pdf",
         "application/msword",
+        "application/xml",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "application/vnd.ms-powerpoint",
         "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/x-tika-ooxml",
         "application/vnd.ms-excel",
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/x-tika-msworks-spreadsheet",
+        "application/vnd.adobe.form.fillsign",
+        "application/illustrator",
+        "application/rtf",
+        "application/x-indesign",
         "image/jpeg",
-        "image/png"
+        "image/png",
+        "image/bmp",
+        "image/gif",
+        "image/vnd.adobe.photoshop",
+        "image/tiff",
+        "message/rfc822",
+        "text/plain"
       ],
       "batchSize": 10
     },


### PR DESCRIPTION
Updating allowed file types to include additional non-PDF formats

Resolves: [MWPW-163777](https://jira.corp.adobe.com/browse/MWPW-163777)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/test/compress-pdf?unitylibs=stage&martech=off
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/test/compress-pdf?unitylibs=MWPW-163777&martech=off
