### PR TITLE
MWPW-167318-Temporary load express page in CC with Unity V2

### DIFF
--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -292,7 +292,8 @@ class WfInitiator {
 }
 
 export default async function init(el, project = 'unity', unityLibs = '/unitylibs', unityVersion = 'v1', langRegion = 'us', langCode = 'en') {
-  const uv = new URLSearchParams(window.location.search).get('unityversion') || unityVersion;
+  let uv = new URLSearchParams(window.location.search).get('unityversion') || unityVersion;
+  if (el.classList.contains('workflow-ai')) uv = 'v2'; //This line will be removed once CC moves to unity V2
   const { imsClientId } = getConfig();
   if (imsClientId) unityConfig.apiKey = imsClientId;
   setUnityLibs(unityLibs, project);


### PR DESCRIPTION
* Temporary load express page in CC with Unity V2

Resolves: [MWPW-167318](https://jira.corp.adobe.com/browse/MWPW-167318)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/hnv/text2image-test-page?unitylibs=stage&martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/hnv/text2image-test-page?unitylibs=v2-express&martech=off
