### PR TITLE
MWPW-168084 | Fix update progress-circle not loading

### DIFF
--- a/unitylibs/core/features/progress-circle/progress-circle.js
+++ b/unitylibs/core/features/progress-circle/progress-circle.js
@@ -1,4 +1,4 @@
-import { createTag } from '../../../scripts/utils.js';
+import { createTag, loadStyle, getUnityLibs } from '../../../scripts/utils.js';
 
 const pdom = `<div class="spectrum-ProgressCircle-track"></div>
   <div class="spectrum-ProgressCircle-fills">
@@ -15,6 +15,7 @@ const pdom = `<div class="spectrum-ProgressCircle-track"></div>
   </div>`;
 
 function createProgressCircle() {
+  loadStyle(`${getUnityLibs()}/core/features/progress-circle/progress-circle.css`);
   const prgc = createTag('div', { class: 'spectrum-ProgressCircle spectrum-ProgressCircle--indeterminate' }, pdom);
   const layer = createTag('div', { class: 'progress-holder' }, prgc);
   return layer;


### PR DESCRIPTION
Fix update progress-circle not loading

Resolves: [MWPW-168084](https://jira.corp.adobe.com/browse/MWPW-168084)

**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.page/products/photoshop/remove-background?martech=off
- After: https://v2fix--unity--adobecom.hlx.page/drafts/mathuria/remove-background?unityversion=v1&martech=off
