### PR TITLE
MWPW-165545 | Acrobat Batch 1a verbs

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -342,7 +342,7 @@ export default class ActionBinder {
     else await this.uploadHandler.multiFileUserUpload(files, filesData);
   }
 
-  async fillsign(files, eventName) {
+  async processSingleFile(files, eventName) {
     if (!files || files.length > this.limits.maxNumFiles) {
       await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
       return;
@@ -350,6 +350,26 @@ export default class ActionBinder {
     const file = files[0];
     if (!file) return;
     await this.handleSingleFileUpload(file, eventName);
+  }
+
+  async fillsign(files, eventName) {
+    await this.processSingleFile(files, eventName);
+  }
+
+  async addComment(files, eventName) {
+    await this.processSingleFile(files, eventName);
+  }
+
+  async numberPages(files, eventName) {
+    await this.processSingleFile(files, eventName);
+  }
+
+  async splitPdf(files, eventName) {
+    await this.processSingleFile(files, eventName);
+  }
+
+  async cropPages(files, eventName) {
+    await this.processSingleFile(files, eventName);
   }
 
   async compress(files, totalFileSize, eventName) {
@@ -360,46 +380,6 @@ export default class ActionBinder {
     const isSingleFile = files.length === 1;
     if (isSingleFile) await this.handleSingleFileUpload(files[0], eventName);
     else await this.handleMultiFileUpload(files, totalFileSize, eventName);
-  }
-
-  async addComment(files, eventName) {
-    if (!files || files.length > this.limits.maxNumFiles) {
-      await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
-      return;
-    }
-    const file = files[0];
-    if (!file) return;
-    await this.handleSingleFileUpload(file, eventName);
-  }
-
-  async numberPages(files, eventName) {
-    if (!files || files.length > this.limits.maxNumFiles) {
-      await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
-      return;
-    }
-    const file = files[0];
-    if (!file) return;
-    await this.handleSingleFileUpload(file, eventName);
-  }
-
-  async splitPdf(files, eventName) {
-    if (!files || files.length > this.limits.maxNumFiles) {
-      await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
-      return;
-    }
-    const file = files[0];
-    if (!file) return;
-    await this.handleSingleFileUpload(file, eventName);
-  }
-
-  async cropPages(files, eventName) {
-    if (!files || files.length > this.limits.maxNumFiles) {
-      await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
-      return;
-    }
-    const file = files[0];
-    if (!file) return;
-    await this.handleSingleFileUpload(file, eventName);
   }
 
   delay(ms) {

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -345,6 +345,46 @@ export default class ActionBinder {
     else await this.handleMultiFileUpload(files, totalFileSize, eventName);
   }
 
+  async addcomment(files, eventName) {
+    if (!files || files.length > this.limits.maxNumFiles) {
+      await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
+      return;
+    }
+    const file = files[0];
+    if (!file) return;
+    await this.handleSingleFileUpload(file, eventName);
+  }
+
+  async numberpages(files, eventName) {
+    if (!files || files.length > this.limits.maxNumFiles) {
+      await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
+      return;
+    }
+    const file = files[0];
+    if (!file) return;
+    await this.handleSingleFileUpload(file, eventName);
+  }
+
+  async splitpdf(files, eventName) {
+    if (!files || files.length > this.limits.maxNumFiles) {
+      await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
+      return;
+    }
+    const file = files[0];
+    if (!file) return;
+    await this.handleSingleFileUpload(file, eventName);
+  }
+
+  async croppages(files, eventName) {
+    if (!files || files.length > this.limits.maxNumFiles) {
+      await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
+      return;
+    }
+    const file = files[0];
+    if (!file) return;
+    await this.handleSingleFileUpload(file, eventName);
+  }
+
   delay(ms) {
     return new Promise((res) => { setTimeout(() => { res(); }, ms); });
   }

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -449,6 +449,22 @@ export default class ActionBinder {
           this.promiseStack = [];
           await this.compress(files, totalFileSize, eventName);
           break;
+        case value.actionType === 'addcomment':
+          this.promiseStack = [];
+          await this.addcomment(files, eventName);
+          break;
+        case value.actionType === 'numberpages':
+          this.promiseStack = [];
+          await this.numberpages(files, eventName);
+          break;
+        case value.actionType === 'splitpdf':
+          this.promiseStack = [];
+          await this.splitpdf(files, eventName);
+          break;
+        case value.actionType === 'croppages':
+          this.promiseStack = [];
+          await this.croppages(files, eventName);
+          break;
         case value.actionType === 'continueInApp':
           await this.continueInApp();
           break;

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /* eslint-disable max-classes-per-file */
 /* eslint-disable no-await-in-loop */
 /* eslint-disable class-methods-use-this */
@@ -137,6 +138,22 @@ export default class ActionBinder {
     this.LOADER_INCREMENT = 30;
     this.LOADER_LIMIT = 95;
     this.MULTI_FILE = false;
+    this.applySignedInSettings();
+  }
+
+  acrobatSignedInSettings() {
+    if (this.limits.signedInallowedFileTypes) this.limits.allowedFileTypes.push(...this.limits.signedInallowedFileTypes);
+  }
+
+  async applySignedInSettings() {
+    if (this.block.classList.includes('signed-in')
+      && window.adobeIMS?.getAccountType() === 'type1') {
+      this.acrobatSignedInSettings();
+      return;
+    }
+    window.addEventListener('IMS:Ready', () => {
+      this.acrobatSignedInSettings();
+    });
   }
 
   getAcrobatApiConfig() {

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -147,7 +147,7 @@ export default class ActionBinder {
 
   async applySignedInSettings() {
     if (this.block.classList.contains('signed-in')
-      && window.adobeIMS?.getAccountType() === 'type1') {
+      && this.getAccountType() === 'type1') {
       this.acrobatSignedInSettings();
       return;
     }

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -362,7 +362,7 @@ export default class ActionBinder {
     else await this.handleMultiFileUpload(files, totalFileSize, eventName);
   }
 
-  async addcomment(files, eventName) {
+  async addComment(files, eventName) {
     if (!files || files.length > this.limits.maxNumFiles) {
       await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
       return;
@@ -372,7 +372,7 @@ export default class ActionBinder {
     await this.handleSingleFileUpload(file, eventName);
   }
 
-  async numberpages(files, eventName) {
+  async numberPages(files, eventName) {
     if (!files || files.length > this.limits.maxNumFiles) {
       await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
       return;
@@ -382,7 +382,7 @@ export default class ActionBinder {
     await this.handleSingleFileUpload(file, eventName);
   }
 
-  async splitpdf(files, eventName) {
+  async splitPdf(files, eventName) {
     if (!files || files.length > this.limits.maxNumFiles) {
       await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
       return;
@@ -392,7 +392,7 @@ export default class ActionBinder {
     await this.handleSingleFileUpload(file, eventName);
   }
 
-  async croppages(files, eventName) {
+  async cropPages(files, eventName) {
     if (!files || files.length > this.limits.maxNumFiles) {
       await this.dispatchErrorToast('verb_upload_error_only_accept_one_file');
       return;
@@ -468,19 +468,19 @@ export default class ActionBinder {
           break;
         case value.actionType === 'addcomment':
           this.promiseStack = [];
-          await this.addcomment(files, eventName);
+          await this.addComment(files, eventName);
           break;
         case value.actionType === 'numberpages':
           this.promiseStack = [];
-          await this.numberpages(files, eventName);
+          await this.numberPages(files, eventName);
           break;
         case value.actionType === 'splitpdf':
           this.promiseStack = [];
-          await this.splitpdf(files, eventName);
+          await this.splitPdf(files, eventName);
           break;
         case value.actionType === 'croppages':
           this.promiseStack = [];
-          await this.croppages(files, eventName);
+          await this.cropPages(files, eventName);
           break;
         case value.actionType === 'continueInApp':
           await this.continueInApp();

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -146,7 +146,7 @@ export default class ActionBinder {
   }
 
   async applySignedInSettings() {
-    if (this.block.classList.includes('signed-in')
+    if (this.block.classList.contains('signed-in')
       && window.adobeIMS?.getAccountType() === 'type1') {
       this.acrobatSignedInSettings();
       return;

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -133,6 +133,68 @@
       ]
     }
   },
+  "verb-widget.split-pdf": {
+    "type": "pdf",
+    "selector": ".verb-wrapper",
+    "handler": "render",
+    "renderWidget": false,
+    "source": ".verb-wrapper .verb-container",
+    "target": ".verb-wrapper .verb-container",
+    "limits": {
+      "maxNumFiles": 1,
+      "maxFileSize": 1073741824,
+      "minNumPages": 1,
+      "maxNumPages": 1500,
+      "allowedFileTypes": ["application/pdf"],
+      "signedInallowedFileTypes": [
+        "application/msword",
+        "application/xml",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/x-tika-ooxml",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/x-tika-msworks-spreadsheet",
+        "application/vnd.adobe.form.fillsign",
+        "application/illustrator",
+        "application/rtf",
+        "application/x-indesign",
+        "image/jpeg",
+        "image/png",
+        "image/bmp",
+        "image/gif",
+        "image/vnd.adobe.photoshop",
+        "image/tiff",
+        "message/rfc822",
+        "text/plain"
+      ],
+      "batchSize": 10
+    },
+    "showSplashScreen": true,
+    "splashScreenConfig": {
+      "fragmentLink": "/dc-shared/fragments/shared-fragments/frictionless/splash-page/splashscreen",
+      "splashScreenParent": "body"
+    },
+    "actionMap": {
+      ".verb-wrapper": [
+        {
+          "actionType": "splitpdf"
+        },
+        {
+          "actionType": "continueInApp"
+        }
+      ],
+      "#file-upload": [
+        {
+          "actionType": "splitpdf"
+        },
+        {
+          "actionType": "continueInApp"
+        }
+      ]
+    }
+  },
   "verb-widget.number-pages": {
     "type": "pdf",
     "selector": ".verb-wrapper",
@@ -163,44 +225,6 @@
       "#file-upload": [
         {
           "actionType": "numberpages"
-        },
-        {
-          "actionType": "continueInApp"
-        }
-      ]
-    }
-  },
-  "verb-widget.split-pdf": {
-    "type": "pdf",
-    "selector": ".verb-wrapper",
-    "handler": "render",
-    "renderWidget": false,
-    "source": ".verb-wrapper .verb-container",
-    "target": ".verb-wrapper .verb-container",
-    "limits": {
-      "maxNumFiles": 1,
-      "maxFileSize": 1073741824,
-      "maxNumPages": 1500,
-      "allowedFileTypes": ["application/pdf"],
-      "batchSize": 10
-    },
-    "showSplashScreen": true,
-    "splashScreenConfig": {
-      "fragmentLink": "/dc-shared/fragments/shared-fragments/frictionless/splash-page/splashscreen",
-      "splashScreenParent": "body"
-    },
-    "actionMap": {
-      ".verb-wrapper": [
-        {
-          "actionType": "splitpdf"
-        },
-        {
-          "actionType": "continueInApp"
-        }
-      ],
-      "#file-upload": [
-        {
-          "actionType": "splitpdf"
         },
         {
           "actionType": "continueInApp"

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -12,8 +12,7 @@
       "pageLimit": {
         "maxNumPages": 100
       },
-      "allowedFileTypes": ["application/pdf"],
-      "batchSize": 10
+      "allowedFileTypes": ["application/pdf"]
     },
     "showSplashScreen": true,
     "splashScreenConfig": {
@@ -71,8 +70,7 @@
         "image/tiff",
         "message/rfc822",
         "text/plain"
-      ],
-      "batchSize": 10
+      ]
     },
     "showSplashScreen": true,
     "splashScreenConfig": {

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -143,7 +143,6 @@
     "limits": {
       "maxNumFiles": 1,
       "maxFileSize": 1073741824,
-      "minNumPages": 1,
       "maxNumPages": 1500,
       "allowedFileTypes": ["application/pdf"],
       "signedInallowedFileTypes": [

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -146,7 +146,7 @@
       "maxNumFiles": 1,
       "maxFileSize": 1073741824,
       "pageLimit": {
-        "minNumPages": 1,
+        "minNumPages": 2,
         "maxNumPages": 1500
       },
       "allowedFileTypes": ["application/pdf"],

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -108,8 +108,7 @@
     "limits": {
       "maxNumFiles": 1,
       "maxFileSize": 104857600,
-      "allowedFileTypes": ["application/pdf"],
-      "batchSize": 10
+      "allowedFileTypes": ["application/pdf"]
     },
     "showSplashScreen": true,
     "splashScreenConfig": {
@@ -172,8 +171,7 @@
         "image/tiff",
         "message/rfc822",
         "text/plain"
-      ],
-      "batchSize": 10
+      ]
     },
     "showSplashScreen": true,
     "splashScreenConfig": {
@@ -209,8 +207,7 @@
     "limits": {
       "maxNumFiles": 1,
       "maxFileSize": 104857600,
-      "allowedFileTypes": ["application/pdf"],
-      "batchSize": 10
+      "allowedFileTypes": ["application/pdf"]
     },
     "showSplashScreen": true,
     "splashScreenConfig": {
@@ -246,8 +243,7 @@
     "limits": {
       "maxNumFiles": 1,
       "maxFileSize": 104857600,
-      "allowedFileTypes": ["application/pdf"],
-      "batchSize": 10
+      "allowedFileTypes": ["application/pdf"]
     },
     "showSplashScreen": true,
     "splashScreenConfig": {

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -106,7 +106,6 @@
     "limits": {
       "maxNumFiles": 1,
       "maxFileSize": 104857600,
-      "maxNumPages": 100,
       "allowedFileTypes": ["application/pdf"],
       "batchSize": 10
     },
@@ -144,7 +143,6 @@
     "limits": {
       "maxNumFiles": 1,
       "maxFileSize": 104857600,
-      "maxNumPages": 100,
       "allowedFileTypes": ["application/pdf"],
       "batchSize": 10
     },
@@ -181,8 +179,8 @@
     "target": ".verb-wrapper .verb-container",
     "limits": {
       "maxNumFiles": 1,
-      "maxFileSize": 104857600,
-      "maxNumPages": 100,
+      "maxFileSize": 1073741824,
+      "maxNumPages": 1500,
       "allowedFileTypes": ["application/pdf"],
       "batchSize": 10
     },
@@ -220,7 +218,6 @@
     "limits": {
       "maxNumFiles": 1,
       "maxFileSize": 104857600,
-      "maxNumPages": 100,
       "allowedFileTypes": ["application/pdf"],
       "batchSize": 10
     },

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -96,6 +96,158 @@
       ]
     }
   },
+  "verb-widget.add-comment": {
+    "type": "pdf",
+    "selector": ".verb-wrapper",
+    "handler": "render",
+    "renderWidget": false,
+    "source": ".verb-wrapper .verb-container",
+    "target": ".verb-wrapper .verb-container",
+    "limits": {
+      "maxNumFiles": 1,
+      "maxFileSize": 104857600,
+      "maxNumPages": 100,
+      "allowedFileTypes": ["application/pdf"],
+      "batchSize": 10
+    },
+    "showSplashScreen": true,
+    "splashScreenConfig": {
+      "fragmentLink": "/dc-shared/fragments/shared-fragments/frictionless/splash-page/splashscreen",
+      "splashScreenParent": "body"
+    },
+    "actionMap": {
+      ".verb-wrapper": [
+        {
+          "actionType": "addcomment"
+        },
+        {
+          "actionType": "continueInApp"
+        }
+      ],
+      "#file-upload": [
+        {
+          "actionType": "addcomment"
+        },
+        {
+          "actionType": "continueInApp"
+        }
+      ]
+    }
+  },
+  "verb-widget.number-pages": {
+    "type": "pdf",
+    "selector": ".verb-wrapper",
+    "handler": "render",
+    "renderWidget": false,
+    "source": ".verb-wrapper .verb-container",
+    "target": ".verb-wrapper .verb-container",
+    "limits": {
+      "maxNumFiles": 1,
+      "maxFileSize": 104857600,
+      "maxNumPages": 100,
+      "allowedFileTypes": ["application/pdf"],
+      "batchSize": 10
+    },
+    "showSplashScreen": true,
+    "splashScreenConfig": {
+      "fragmentLink": "/dc-shared/fragments/shared-fragments/frictionless/splash-page/splashscreen",
+      "splashScreenParent": "body"
+    },
+    "actionMap": {
+      ".verb-wrapper": [
+        {
+          "actionType": "numberpages"
+        },
+        {
+          "actionType": "continueInApp"
+        }
+      ],
+      "#file-upload": [
+        {
+          "actionType": "numberpages"
+        },
+        {
+          "actionType": "continueInApp"
+        }
+      ]
+    }
+  },
+  "verb-widget.split-pdf": {
+    "type": "pdf",
+    "selector": ".verb-wrapper",
+    "handler": "render",
+    "renderWidget": false,
+    "source": ".verb-wrapper .verb-container",
+    "target": ".verb-wrapper .verb-container",
+    "limits": {
+      "maxNumFiles": 1,
+      "maxFileSize": 104857600,
+      "maxNumPages": 100,
+      "allowedFileTypes": ["application/pdf"],
+      "batchSize": 10
+    },
+    "showSplashScreen": true,
+    "splashScreenConfig": {
+      "fragmentLink": "/dc-shared/fragments/shared-fragments/frictionless/splash-page/splashscreen",
+      "splashScreenParent": "body"
+    },
+    "actionMap": {
+      ".verb-wrapper": [
+        {
+          "actionType": "splitpdf"
+        },
+        {
+          "actionType": "continueInApp"
+        }
+      ],
+      "#file-upload": [
+        {
+          "actionType": "splitpdf"
+        },
+        {
+          "actionType": "continueInApp"
+        }
+      ]
+    }
+  },
+  "verb-widget.crop-pages": {
+    "type": "pdf",
+    "selector": ".verb-wrapper",
+    "handler": "render",
+    "renderWidget": false,
+    "source": ".verb-wrapper .verb-container",
+    "target": ".verb-wrapper .verb-container",
+    "limits": {
+      "maxNumFiles": 1,
+      "maxFileSize": 104857600,
+      "maxNumPages": 100,
+      "allowedFileTypes": ["application/pdf"],
+      "batchSize": 10
+    },
+    "showSplashScreen": true,
+    "splashScreenConfig": {
+      "fragmentLink": "/dc-shared/fragments/shared-fragments/frictionless/splash-page/splashscreen",
+      "splashScreenParent": "body"
+    },
+    "actionMap": {
+      ".verb-wrapper": [
+        {
+          "actionType": "croppages"
+        },
+        {
+          "actionType": "continueInApp"
+        }
+      ],
+      "#file-upload": [
+        {
+          "actionType": "croppages"
+        },
+        {
+          "actionType": "continueInApp"
+        }
+      ]
+    }
+  },
   "marquee": {
     "type": "pdf",
     "selector": ".action-area",

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -9,7 +9,9 @@
     "limits": {
       "maxNumFiles": 1,
       "maxFileSize": 104857600,
-      "maxNumPages": 100,
+      "pageLimit": {
+        "maxNumPages": 100
+      },
       "allowedFileTypes": ["application/pdf"],
       "batchSize": 10
     },
@@ -143,7 +145,10 @@
     "limits": {
       "maxNumFiles": 1,
       "maxFileSize": 1073741824,
-      "maxNumPages": 1500,
+      "pageLimit": {
+        "minNumPages": 1,
+        "maxNumPages": 1500
+      },
       "allowedFileTypes": ["application/pdf"],
       "signedInallowedFileTypes": [
         "application/msword",

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -186,6 +186,53 @@ export default class UploadHandler {
     }
   }
 
+  async isAboveMinPageLimit(assetData) {
+    try {
+      const intervalDuration = 500;
+      const totalDuration = 5000;
+      let metadata = {};
+      let intervalId;
+      let requestInProgress = false;
+      let metadataExists = false;
+      return new Promise((resolve) => {
+        const handleMetadata = async () => {
+          if (metadata.numPages <= this.actionBinder.limits.minNumPages) {
+            await this.actionBinder.showSplashScreen();
+            await this.actionBinder.dispatchErrorToast('verb_upload_error_min_page_count');
+            resolve(true);
+            return;
+          }
+          resolve(false);
+        };
+        intervalId = setInterval(async () => {
+          if (requestInProgress) return;
+          requestInProgress = true;
+          metadata = await this.serviceHandler.getCallToService(
+            this.actionBinder.acrobatApiConfig.acrobatEndpoint.getMetadata,
+            { id: assetData.id },
+          );
+          requestInProgress = false;
+          if (metadata?.numPages !== undefined) {
+            clearInterval(intervalId);
+            clearTimeout(timeoutId);
+            metadataExists = true;
+            await handleMetadata();
+          }
+        }, intervalDuration);
+        const timeoutId = setTimeout(async () => {
+          clearInterval(intervalId);
+          if (!metadataExists) resolve(false);
+          else await handleMetadata();
+        }, totalDuration);
+      });
+    } catch (e) {
+      await this.actionBinder.showSplashScreen();
+      await this.actionBinder.dispatchErrorToast('verb_upload_error_generic', 500, 'Exception thrown when verifying PDF page count.', false, e.showError);
+      this.actionBinder.operations = [];
+      return false;
+    }
+  }
+
   async handleValidations(assetData) {
     let validated = true;
     for (const limit of Object.keys(this.actionBinder.limits)) {
@@ -193,6 +240,11 @@ export default class UploadHandler {
         case 'maxNumPages': {
           const maxPageLimitExceeded = await this.isMaxPageLimitExceeded(assetData);
           if (maxPageLimitExceeded) validated = false;
+          break;
+        }
+        case 'minNumPages': {
+          const minPageLimit = await this.isAboveMinPageLimit(assetData);
+          if (minPageLimit) validated = false;
           break;
         }
         default:

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -139,7 +139,7 @@ export default class UploadHandler {
     return true;
   }
 
-  async isMaxPageLimitExceeded(assetData) {
+  async checkPageNumCount(assetData) {
     try {
       const intervalDuration = 500;
       const totalDuration = 5000;
@@ -149,9 +149,19 @@ export default class UploadHandler {
       let metadataExists = false;
       return new Promise((resolve) => {
         const handleMetadata = async () => {
-          if (metadata.numPages > this.actionBinder.limits.maxNumPages) {
+          if (this.actionBinder?.limits?.pageLimit?.maxNumPages
+            && metadata.numPages > this.actionBinder.limits.pageLimit.maxNumPages
+          ) {
             await this.actionBinder.showSplashScreen();
             await this.actionBinder.dispatchErrorToast('verb_upload_error_max_page_count');
+            resolve(true);
+            return;
+          }
+          if (this.actionBinder?.limits?.pageLimit?.minNumPages
+            && metadata.numPages < this.actionBinder.limits.pageLimit.minNumPages
+          ) {
+            await this.actionBinder.showSplashScreen();
+            await this.actionBinder.dispatchErrorToast('verb_upload_error_min_page_count');
             resolve(true);
             return;
           }
@@ -190,9 +200,9 @@ export default class UploadHandler {
     let validated = true;
     for (const limit of Object.keys(this.actionBinder.limits)) {
       switch (limit) {
-        case 'maxNumPages': {
-          const maxPageLimitExceeded = await this.isMaxPageLimitExceeded(assetData);
-          if (maxPageLimitExceeded) validated = false;
+        case 'pageLimit': {
+          const pageLimitRes = await this.checkPageNumCount(assetData);
+          if (pageLimitRes) validated = false;
           break;
         }
         default:
@@ -295,8 +305,10 @@ export default class UploadHandler {
     this.actionBinder.operations.push(assetData.id);
     const verified = await this.verifyContent(assetData);
     if (!verified) return;
-    const validated = await this.handleValidations(assetData);
-    if (!validated) return;
+    if (!isNonPdf) {
+      const validated = await this.handleValidations(assetData);
+      if (!validated) return;
+    }
     this.actionBinder.dispatchAnalyticsEvent('uploaded');
   }
 

--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -266,7 +266,14 @@ class WfInitiator {
       },
       'workflow-acrobat': {
         productName: 'acrobat',
-        sfList: new Set(['fillsign', 'compress-pdf']),
+        sfList: new Set([
+          'fillsign',
+          'compress-pdf',
+          'add-comment',
+          'number-pages',
+          'split-pdf',
+          'crop-pages',
+        ]),
       },
       'workflow-ai': {
         productName: 'Express',


### PR DESCRIPTION
Adding support for acrobat 1a verbs:
-   add-comment
-   number-pages
-   split-pdf
-   crop-pages

Supports
- Single file upload
- Only PDF for add-comment, number-pages, split-pdf (signed out) , crop-pages
- All file formats for split-pdf (signed in)
- Min page requirement of 2 page and max 1500 for split-pdf.

Resolves: [MWPW-165545](https://jira.corp.adobe.com/browse/MWPW-165545)

**Test URLs:**
- https://stage--dc--adobecom.hlx.page/acrobat/online/test/pdf-editor?unitylibs=acrobat1a
- https://stage--dc--adobecom.hlx.page/acrobat/online/test/add-pdf-page-numbers?unitylibs=acrobat1a
- https://stage--dc--adobecom.hlx.page/acrobat/online/test/split-pdf?unitylibs=acrobat1a
- https://stage--dc--adobecom.hlx.page/acrobat/online/test/crop-pdf?unitylibs=acrobat1a

- URL for PSI git check - https://acrobat1a--unity--adobecom.hlx.live/drafts/mathuria/remove-background?martech=off
