### PR TITLE
MWPW-163640: [BugFix] Refactor token retrieval in common utils to use refreshToken

### DIFF
--- a/unitylibs/core/steps/app-connector.js
+++ b/unitylibs/core/steps/app-connector.js
@@ -51,7 +51,7 @@ async function continueInApp(cfg, appName, btnConfig) {
     const data = getPreludeData(cfg);
     const connectorOptions = {
       method: 'POST',
-      headers: getHeaders(apiKey),
+      headers: await getHeaders(apiKey),
       body: JSON.stringify(data),
     };
     const response = await fetch(connectorApiEndPoint, connectorOptions);

--- a/unitylibs/core/steps/upload-step.js
+++ b/unitylibs/core/steps/upload-step.js
@@ -42,7 +42,7 @@ export async function uploadAsset(cfg, imgUrl) {
   const { showErrorToast } = await import('../../scripts/utils.js');
   const genIdOptions = {
     method: 'POST',
-    headers: getHeaders(apiKey),
+    headers: await getHeaders(apiKey),
   };
   const response = await fetch(`${apiEndPoint}/asset`, genIdOptions);
   if (response.status !== 200) {
@@ -61,7 +61,7 @@ export async function scanImgForSafety(cfg, assetId) {
   const assetData = { assetId, targetProduct: 'Photoshop' };
   const imgScanOptions = {
     method: 'POST',
-    headers: getHeaders(apiKey),
+    headers: await getHeaders(apiKey),
     body: JSON.stringify(assetData),
   };
   return fetch(`${apiEndPoint}/asset/finalize`, imgScanOptions);

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -12,48 +12,16 @@ import {
   priorityLoad,
   loadArea,
   loadImg,
+  getGuestAccessToken
 } from '../../../scripts/utils.js';
 
 class ServiceHandler {
-  getGuestAccessToken() {
-    try {
-      return window.adobeIMS.getAccessToken();
-    } catch (e) {
-      return '';
-    }
-  }
-
-  async getRefreshToken() {
-    try {
-      const { tokenInfo } = await window.adobeIMS.refreshToken();
-      return `Bearer ${tokenInfo.token}`;
-    } catch (e) {
-      return '';
-    }
-  }
 
   async getHeaders() {
-    let token = '';
-    let refresh = false;
-    const guestAccessToken = this.getGuestAccessToken();
-    if (!guestAccessToken || guestAccessToken.expire.valueOf() <= Date.now() + (5 * 60 * 1000)) {
-      token = await this.getRefreshToken();
-      refresh = true;
-    } else {
-      token = `Bearer ${guestAccessToken.token}`;
-    }
-
-    if (!token) {
-      const error = new Error();
-      error.status = 401;
-      error.message = `Access Token is null. Refresh token call was executed: ${refresh}`
-      throw error;
-    }
-
     return {
       headers: {
         'Content-Type': 'application/json',
-        Authorization: token,
+        Authorization: await getGuestAccessToken(),
         'x-api-key': unityConfig.apiKey,
       },
     };

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -12,20 +12,10 @@ import {
   priorityLoad,
   loadArea,
   loadImg,
-  getGuestAccessToken
+  getHeaders
 } from '../../../scripts/utils.js';
 
 class ServiceHandler {
-
-  async getHeaders() {
-    return {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: await getGuestAccessToken(),
-        'x-api-key': unityConfig.apiKey,
-      },
-    };
-  }
 
   async fetchFromService(url, options) {
     try {
@@ -53,7 +43,7 @@ class ServiceHandler {
   }
 
   async postCallToService(api, options) {
-    const headers = await this.getHeaders();
+    const headers = await getHeaders(unityConfig.apiKey);
     const postOpts = {
       method: 'POST',
       ...headers,
@@ -63,7 +53,7 @@ class ServiceHandler {
   }
 
   async getCallToService(api, params) {
-    const headers = await this.getHeaders();
+    const headers = await getHeaders(unityConfig.apiKey);
     const getOpts = {
       method: 'GET',
       ...headers,

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -43,20 +43,18 @@ class ServiceHandler {
   }
 
   async postCallToService(api, options) {
-    const headers = await getHeaders(unityConfig.apiKey);
     const postOpts = {
       method: 'POST',
-      ...headers,
+      headers: await getHeaders(unityConfig.apiKey),
       ...options,
     };
     return this.fetchFromService(api, postOpts);
   }
 
   async getCallToService(api, params) {
-    const headers = await getHeaders(unityConfig.apiKey);
     const getOpts = {
       method: 'GET',
-      ...headers,
+      headers: await getHeaders(unityConfig.apiKey),
     };
     const queryString = new URLSearchParams(params).toString();
     const url = `${api}?${queryString}`;

--- a/unitylibs/core/workflow/workflow-ai/service-handler.js
+++ b/unitylibs/core/workflow/workflow-ai/service-handler.js
@@ -3,45 +3,18 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable no-restricted-syntax */
 
-import { unityConfig } from '../../../scripts/utils.js';
-
+import { unityConfig, getGuestAccessToken } from '../../../scripts/utils.js';
 export default class ServiceHandler {
   constructor(renderWidget = false, canvasArea = null) {
     this.renderWidget = renderWidget;
     this.canvasArea = canvasArea;
   }
 
-  async getRefreshToken() {
-    try {
-      const { tokenInfo } = await window.adobeIMS.refreshToken();
-      return `Bearer ${tokenInfo.token}`;
-    } catch (e) {
-      return '';
-    }
-  }
-
   async getHeaders() {
-    let token = '';
-    let refresh = false;
-    const guestAccessToken = window.adobeIMS?.getAccessToken();
-    if (!guestAccessToken || guestAccessToken.expire.valueOf() <= Date.now() + (5 * 60 * 1000)) {
-      token = await this.getRefreshToken();
-      refresh = true;
-    } else {
-      token = `Bearer ${guestAccessToken.token}`;
-    }
-
-    if (!token) {
-      const error = new Error();
-      error.status = 401;
-      error.message = `Unauthorized Access: ${refresh}`;
-      throw error;
-    }
-
     return {
       headers: {
         'Content-Type': 'application/json',
-        Authorization: token,
+        Authorization: await getGuestAccessToken(),
         'x-api-key': unityConfig.apiKey,
       },
     };

--- a/unitylibs/core/workflow/workflow-ai/service-handler.js
+++ b/unitylibs/core/workflow/workflow-ai/service-handler.js
@@ -28,10 +28,9 @@ export default class ServiceHandler {
   }
 
   async postCallToService(api, options) {
-    const headers = await getHeaders(unityConfig.apiKey);
     const postOpts = {
       method: 'POST',
-      ...headers,
+      headers: await getHeaders(unityConfig.apiKey),
       ...options,
     };
     return this.fetchFromService(api, postOpts);

--- a/unitylibs/core/workflow/workflow-ai/service-handler.js
+++ b/unitylibs/core/workflow/workflow-ai/service-handler.js
@@ -3,21 +3,11 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable no-restricted-syntax */
 
-import { unityConfig, getGuestAccessToken } from '../../../scripts/utils.js';
+import { unityConfig, getHeaders} from '../../../scripts/utils.js';
 export default class ServiceHandler {
   constructor(renderWidget = false, canvasArea = null) {
     this.renderWidget = renderWidget;
     this.canvasArea = canvasArea;
-  }
-
-  async getHeaders() {
-    return {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: await getGuestAccessToken(),
-        'x-api-key': unityConfig.apiKey,
-      },
-    };
   }
 
   async fetchFromService(url, options) {
@@ -38,7 +28,7 @@ export default class ServiceHandler {
   }
 
   async postCallToService(api, options) {
-    const headers = await this.getHeaders();
+    const headers = await getHeaders(unityConfig.apiKey);
     const postOpts = {
       method: 'POST',
       ...headers,

--- a/unitylibs/core/workflow/workflow-ai/service-handler.js
+++ b/unitylibs/core/workflow/workflow-ai/service-handler.js
@@ -3,7 +3,7 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable no-restricted-syntax */
 
-import { unityConfig, getHeaders} from '../../../scripts/utils.js';
+import { unityConfig, getHeaders } from '../../../scripts/utils.js';
 export default class ServiceHandler {
   constructor(renderWidget = false, canvasArea = null) {
     this.renderWidget = renderWidget;

--- a/unitylibs/core/workflow/workflow-photoshop/action-binder.js
+++ b/unitylibs/core/workflow/workflow-photoshop/action-binder.js
@@ -30,11 +30,11 @@ class ServiceHandler {
     this.unityEl = unityEl;
   }
 
-  getHeaders() {
+  async getHeaders() {
     return {
       headers: {
         'Content-Type': 'application/json',
-        Authorization: getGuestAccessToken(),
+        Authorization: await getGuestAccessToken(),
         'x-api-key': unityConfig.apiKey,
       },
     };
@@ -43,7 +43,7 @@ class ServiceHandler {
   async postCallToService(api, options, errorCallbackOptions = {}, failOnError = true) {
     const postOpts = {
       method: 'POST',
-      ...this.getHeaders(),
+      ...await this.getHeaders(),
       ...options,
     };
     try {

--- a/unitylibs/core/workflow/workflow-photoshop/action-binder.js
+++ b/unitylibs/core/workflow/workflow-photoshop/action-binder.js
@@ -33,7 +33,7 @@ class ServiceHandler {
   async postCallToService(api, options, errorCallbackOptions = {}, failOnError = true) {
     const postOpts = {
       method: 'POST',
-      ...await getHeaders(unityConfig.apiKey),
+      headers: await getHeaders(unityConfig.apiKey),
       ...options,
     };
     try {

--- a/unitylibs/core/workflow/workflow-photoshop/action-binder.js
+++ b/unitylibs/core/workflow/workflow-photoshop/action-binder.js
@@ -6,7 +6,7 @@
 /* eslint-disable no-restricted-syntax */
 
 import {
-  getGuestAccessToken,
+  getHeaders,
   unityConfig,
   loadImg,
   createTag,
@@ -30,20 +30,10 @@ class ServiceHandler {
     this.unityEl = unityEl;
   }
 
-  async getHeaders() {
-    return {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: await getGuestAccessToken(),
-        'x-api-key': unityConfig.apiKey,
-      },
-    };
-  }
-
   async postCallToService(api, options, errorCallbackOptions = {}, failOnError = true) {
     const postOpts = {
       method: 'POST',
-      ...await this.getHeaders(),
+      ...await getHeaders(unityConfig.apiKey),
       ...options,
     };
     try {

--- a/unitylibs/core/workflow/workflow-photoshop/workflow-photoshop.js
+++ b/unitylibs/core/workflow/workflow-photoshop/workflow-photoshop.js
@@ -193,7 +193,7 @@ async function removeBgHandler(cfg, changeDisplay = true, cachedImg=null) {
   cfg.preludeState.assetId = id;
   const removeBgOptions = {
     method: 'POST',
-    headers: getHeaders(apiKey),
+    headers: await getHeaders(apiKey),
     body: `{"surfaceId":"Unity","assets":[{"id": "${id}"}]}`,
   };
   const response = await fetch(`${apiEndPoint}/${endpoint}`, removeBgOptions);
@@ -267,7 +267,7 @@ async function changeBgHandler(cfg, selectedUrl = null, refreshState = true, cac
   }
   const changeBgOptions = {
     method: 'POST',
-    headers: getHeaders(apiKey),
+    headers: await getHeaders(apiKey),
     body: `{
             "assets": [{ "id": "${fgId}" },{ "id": "${bgId}" }],
             "metadata": {

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -39,7 +39,7 @@ export {
 
 async function getRefreshToken() {
   try {
-    const { tokenInfo } = await window.adobeIMS.refreshToken();
+    const { tokenInfo } = await window.adobeIMS?.refreshToken();
     return `Bearer ${tokenInfo.token}`;
   } catch (e) {
     return '';
@@ -47,7 +47,7 @@ async function getRefreshToken() {
 }
 
 export async function getGuestAccessToken() {
-  let guestAccessToken = window.adobeIMS.getAccessToken();
+  let guestAccessToken = window.adobeIMS?.getAccessToken();
   if (guestAccessToken?.expire.valueOf() <= Date.now() + (5 * 60 * 1000)) {
     return await getRefreshToken();
   } else {

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -37,19 +37,28 @@ export {
   createTag, loadStyle, getConfig, loadLink, loadScript, localizeLink, loadArea,
 };
 
-export function getGuestAccessToken() {
+async function getRefreshToken() {
   try {
-    const { token } = window.adobeIMS.getAccessToken();
-    return `Bearer ${token}`;
+    const { tokenInfo } = await window.adobeIMS.refreshToken();
+    return `Bearer ${tokenInfo.token}`;
   } catch (e) {
     return '';
   }
 }
 
-export function getHeaders(apiKey) {
+export async function getGuestAccessToken() {
+  let guestAccessToken = window.adobeIMS.getAccessToken();
+  if (guestAccessToken?.expire.valueOf() <= Date.now() + (5 * 60 * 1000)) {
+    return await getRefreshToken();
+  } else {
+    return `Bearer ${guestAccessToken?.token}`;
+  }
+}
+
+export async function getHeaders(apiKey) {
   return {
     'Content-Type': 'application/json',
-    Authorization: getGuestAccessToken(),
+    Authorization: await getGuestAccessToken(),
     'x-api-key': apiKey,
   };
 }

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -57,11 +57,9 @@ export async function getGuestAccessToken() {
 
 export async function getHeaders(apiKey) {
   return {
-    headers: {
       'Content-Type': 'application/json',
       Authorization: await getGuestAccessToken(),
       'x-api-key': apiKey,
-    }
   };
 }
 

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -57,9 +57,11 @@ export async function getGuestAccessToken() {
 
 export async function getHeaders(apiKey) {
   return {
-    'Content-Type': 'application/json',
-    Authorization: await getGuestAccessToken(),
-    'x-api-key': apiKey,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: await getGuestAccessToken(),
+      'x-api-key': apiKey,
+    }
   };
 }
 


### PR DESCRIPTION
This PR is copy of https://github.com/adobecom/unity/pull/273 along with the bug fix.
Bug fix:
The existing getHeaders() function in utils did not return a key value pair like `headers : {}`. Refactored now to make headers a key value pair at function invocation.

Refactoring:
In the common utils file, the function getGuestAccessToken is refactored to retrieve the refreshToken when the accessToken has expired.

Note: Added changes for v1 API as well for backward compatibility


Resolves: [MWPW-163640](https://jira.corp.adobe.com/browse/MWPW-163640)

**Test URLs:**

PS
- Before: https://stage--cc--adobecom.hlx.page/products/photoshop/remove-background?martech=off 
- After: https://stage--cc--adobecom.hlx.page/products/photoshop/remove-background?unitylibs=mwpw-163640-fix&martech=off
- PSI test: https://mwpw-163640-fix--unity--adobecom.hlx.page/drafts/mathuria/remove-background?martech=off

Express
https://stage--cc--adobecom.hlx.page/drafts/hnv/text2image-test-page?unitylibs=mwpw-163640-fix&martech=off

Acrobat
https://stage--dc--adobecom.hlx.page/acrobat/online/crop-pdf?unitylibs=mwpw-163640-fix&martech=off

