### PR TITLE
MWPW-168306 Fix for setting account type class variable

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -149,8 +149,8 @@ export default class ActionBinder {
   }
 
   async applySignedInSettings() {
+    this.accountType = await this.getAccountType();
     if (this.block.classList.contains('signed-in')) {
-      this.accountType = await this.getAccountType();
       if (this.accountType === 'type1') {
         this.acrobatSignedInSettings();
         return;


### PR DESCRIPTION
- Ensuring account type class variable is set upon ActionBinder construction

Resolves: [MWPW-168306](https://jira.corp.adobe.com/browse/MWPW-168306)

Test URLs:
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=stage
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=MWPW-168306