### PR TITLE
MWPW-168743 Ensure fileData is passed to analytics for SFU

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -336,8 +336,8 @@ export default class ActionBinder {
     }
     const { default: UploadHandler } = await import(`${getUnityLibs()}/core/workflow/${this.workflowCfg.name}/upload-handler.js`);
     this.uploadHandler = new UploadHandler(this, this.serviceHandler);
-    if (this.accountType === 'guest') await this.uploadHandler.singleFileGuestUpload(file);
-    else await this.uploadHandler.singleFileUserUpload(file);
+    if (this.accountType === 'guest') await this.uploadHandler.singleFileGuestUpload(file, fileData);
+    else await this.uploadHandler.singleFileUserUpload(file, fileData);
   }
 
   async handleMultiFileUpload(files, totalFileSize, eventName) {

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -275,7 +275,7 @@ export default class UploadHandler {
     return files.some((file) => file.type !== 'application/pdf');
   }
 
-  async uploadSingleFile(file, isNonPdf = false) {
+  async uploadSingleFile(file, fileData, isNonPdf = false) {
     const { maxConcurrentChunks } = this.getConcurrentLimits();
     let cOpts = {};
     const [blobData, assetData] = await Promise.all([
@@ -301,7 +301,7 @@ export default class UploadHandler {
     };
     const redirectSuccess = await this.actionBinder.handleRedirect(cOpts);
     if (!redirectSuccess) return;
-    this.actionBinder.dispatchAnalyticsEvent('uploading', assetData);
+    this.actionBinder.dispatchAnalyticsEvent('uploading', fileData);
     const uploadResult = await this.chunkPdf(
       [assetData],
       [blobData],
@@ -319,10 +319,10 @@ export default class UploadHandler {
       const validated = await this.handleValidations(assetData);
       if (!validated) return;
     }
-    this.actionBinder.dispatchAnalyticsEvent('uploaded');
+    this.actionBinder.dispatchAnalyticsEvent('uploaded', fileData);
   }
 
-  async singleFileGuestUpload(file) {
+  async singleFileGuestUpload(file, fileData) {
     try {
       await this.actionBinder.showSplashScreen(true);
       if (this.isNonPdf([file])) {
@@ -332,7 +332,7 @@ export default class UploadHandler {
         this.actionBinder.redirectWithoutUpload = true;
         return;
       }
-      await this.uploadSingleFile(file);
+      await this.uploadSingleFile(file, fileData);
     } catch (e) {
       await this.actionBinder.showSplashScreen();
       this.actionBinder.operations = [];
@@ -340,10 +340,10 @@ export default class UploadHandler {
     }
   }
 
-  async singleFileUserUpload(file) {
+  async singleFileUserUpload(file, fileData) {
     try {
       await this.actionBinder.showSplashScreen(true);
-      await this.uploadSingleFile(file, this.isNonPdf([file]));
+      await this.uploadSingleFile(file, fileData, this.isNonPdf([file]));
     } catch (e) {
       await this.actionBinder.showSplashScreen();
       this.actionBinder.operations = [];


### PR DESCRIPTION
- Ensure `fileData` is included when dispatching analytics calls for single file upload

Resolves: [MWPW-168743](https://jira.corp.adobe.com/browse/MWPW-168743)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=stage
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=MWPW-168743