### PR TITLE
Fixing the acrobat finalize header failure

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -132,9 +132,10 @@ class ServiceHandler {
   }
 
   async postCallToServiceWithRetry(api, options) {
+    const headers = await this.getHeaders();
     const postOpts = {
       method: 'POST',
-      headers: await getHeaders(unityConfig.apiKey),
+      ...headers,
       ...options,
     };
     return this.fetchFromServiceWithRetry(api, postOpts);


### PR DESCRIPTION
Fixing the acrobat finalize header failure

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--unity--adobecom.aem.page/?martech=off
- After: https://<branch>--unity--adobecom.aem.page/?martech=off
