### PR TITLE
MWPW-169252 | Fix the block on reupload of same image for Chrome and Safari

### DIFF
--- a/unitylibs/core/workflow/workflow-photoshop/action-binder.js
+++ b/unitylibs/core/workflow/workflow-photoshop/action-binder.js
@@ -334,6 +334,7 @@ export default class ActionBinder {
     };
     const objUrl = URL.createObjectURL(file);
     params.target.src = objUrl;
+    e.target.value = null;
     let loadSuccessful = false;
     await new Promise((res) => {
       params.target.onload = () => {


### PR DESCRIPTION
Fix the block on reupload of same image for Chrome and Safari

Resolves: [MWPW-169252](https://jira.corp.adobe.com/browse/MWPW-169252)

**Test URLs:**
- Before: https://main--unity--adobecom.aem.page/drafts/mathuria/remove-backgrond?martech=off
- After: https://MWPW-169252--unity--adobecom.aem.page/remove-backgrond?martech=off
