### PR TITLE
MWPW-169302 & MWPW-169285 | Making the widget consistent with figma and faster thumbnail loading

### DIFF
--- a/unitylibs/core/styles/styles.css
+++ b/unitylibs/core/styles/styles.css
@@ -364,14 +364,17 @@
     display: none;
     height: 100%;
   }
-
+  
   .unity-enabled .interactive-area .unity-action-area .unity-action-btn.show ~ .unity-action-btn.show {
     border-left: 1px solid var(--separator-gray);
+    border-right: none;
   }
 
   [dir="rtl"] .unity-enabled .interactive-area .unity-action-area .unity-action-btn.show ~ .unity-action-btn.show {
-    border-left: 1px solid var(--separator-gray);
+    border-right: 1px solid var(--separator-gray);
+    border-left: none;
   }
+
 
   .unity-enabled .interactive-area.light .unity-action-area {
     background: var(--light-bg);

--- a/unitylibs/core/styles/styles.css
+++ b/unitylibs/core/styles/styles.css
@@ -369,6 +369,10 @@
     border-left: 1px solid var(--separator-gray);
   }
 
+  [dir="rtl"] .unity-enabled .interactive-area .unity-action-area .unity-action-btn.show ~ .unity-action-btn.show {
+    border-left: 1px solid var(--separator-gray);
+  }
+
   .unity-enabled .interactive-area.light .unity-action-area {
     background: var(--light-bg);
   }

--- a/unitylibs/core/workflow/workflow-photoshop/widget.css
+++ b/unitylibs/core/workflow/workflow-photoshop/widget.css
@@ -137,10 +137,12 @@
     object-fit: cover;
   }
 
+  .unity-enabled .interactive-area .unity-action-btn.focus .btn-text,
+  .unity-enabled .interactive-area .unity-action-btn.focus:not(.continue-in-app) .btn-icon svg path,
   .unity-enabled .interactive-area .unity-action-btn:active .btn-text,
-  .unity-enabled .interactive-area .unity-action-btn:active .btn-icon svg path {
+  .unity-enabled .interactive-area .unity-action-btn:active:not(.continue-in-app) .btn-icon svg path {
     color: var(--highlight-blue);
-    fill: var(--highlight-blue);
+    fill: var(--highlight-blue) !important;
   }
 }
 

--- a/unitylibs/core/workflow/workflow-photoshop/widget.js
+++ b/unitylibs/core/workflow/workflow-photoshop/widget.js
@@ -343,7 +343,7 @@ export default class UnityWidget {
     [...bgOptions].forEach((o, num) => {
       let thumbnail = null;
       let bgImg = null;
-      [thumbnail, bgImg] = o.querySelectorAll(':scope> picture > img');
+      [thumbnail, bgImg] = o.querySelectorAll(':scope > picture > img');
       if (!bgImg) bgImg = thumbnail;
       thumbnail.dataset.backgroundImg = bgImg.src;
       thumbnail.setAttribute('src', this.updateQueryParam(bgImg.src, { format: 'webply', width: '68', height: '68' }));

--- a/unitylibs/core/workflow/workflow-photoshop/widget.js
+++ b/unitylibs/core/workflow/workflow-photoshop/widget.js
@@ -346,7 +346,7 @@ export default class UnityWidget {
       [thumbnail, bgImg] = o.querySelectorAll(':scope> picture > img');
       if (!bgImg) bgImg = thumbnail;
       thumbnail.dataset.backgroundImg = bgImg.src;
-      thumbnail.setAttribute('src', updateQueryParam(bgImg.src, { format: 'webply', width: '68', height: '68' }));
+      thumbnail.setAttribute('src', this.updateQueryParam(bgImg.src, { format: 'webply', width: '68', height: '68' }));
       const optionSelector = `changebg-option option-${num}`;
       const a = createTag('a', { href: '#', class: optionSelector }, thumbnail);
       bgSelectorTray.append(a);

--- a/unitylibs/core/workflow/workflow-photoshop/widget.js
+++ b/unitylibs/core/workflow/workflow-photoshop/widget.js
@@ -56,7 +56,7 @@ export default class UnityWidget {
   }
 
   createActionBtn(btnCfg, btnClass, imgId, swapOrder = false) {
-    const btnIcon = createTag('div', { class: 'btn-icon' }, `<svg><use xlink:href="#unity-${imgId}-icon"></use></svg>`);
+    const btnIcon = createTag('div', { class: 'btn-icon' }, this.widget.querySelector(`#unity-${imgId}-icon svg`).outerHTML);
     const btnText = createTag('div', { class: 'btn-text' }, btnCfg.innerText.split('\n')[0].trim());
     const actionBtn = createTag('a', { href: '#', class: `unity-action-btn ${btnClass}` }, btnText);
     if (swapOrder) actionBtn.append(btnIcon);
@@ -343,9 +343,10 @@ export default class UnityWidget {
     [...bgOptions].forEach((o, num) => {
       let thumbnail = null;
       let bgImg = null;
-      [thumbnail, bgImg] = o.querySelectorAll('img');
+      [thumbnail, bgImg] = o.querySelectorAll(':scope> picture > img');
       if (!bgImg) bgImg = thumbnail;
       thumbnail.dataset.backgroundImg = bgImg.src;
+      thumbnail.setAttribute('src', updateQueryParam(bgImg.src, { format: 'webply', width: '68', height: '68' }));
       const optionSelector = `changebg-option option-${num}`;
       const a = createTag('a', { href: '#', class: optionSelector }, thumbnail);
       bgSelectorTray.append(a);


### PR DESCRIPTION
- As per figma, updating the button svg to be blue when active
- Making thumbnail load faster by using lower resolution images

Resolves:
[MWPW-169302](https://jira.corp.adobe.com/browse/MWPW-169302)
[MWPW-169285](https://jira.corp.adobe.com/browse/MWPW-169285)

**Test URLs:**

- Before: https://main--unity--adobecom.aem.live/drafts/mathuria/remove-background?martech=off
- After: https://MWPW-169302--unity--adobecom.aem.live/drafts/mathuria/remove-background?martech=off

- Before: https://main--unity--adobecom.aem.live/drafts/mathuria/remove-background-cache?martech=off
- After: https://MWPW-169302--unity--adobecom.aem.live/drafts/mathuria/remove-background-cache?martech=off
