### PR TITLE
MWPW-169374 | Remove underline from button text from mobile in V2

### DIFF
--- a/unitylibs/core/styles/styles.css
+++ b/unitylibs/core/styles/styles.css
@@ -420,6 +420,7 @@
     fill: var(--highlight-blue);
   }
 
+  .unity-enabled .interactive-area .unity-action-area .unity-action-btn,
   .unity-enabled .interactive-area .unity-action-area .unity-action-btn:hover {
     text-decoration: none;
   }


### PR DESCRIPTION
Unity Ps [PROD and Stage] Text is underlined in unity widget in mobile and as per figma there should be no underline.
Fixing this in V2

Resolves: [MWPW-169374](https://jira.corp.adobe.com/browse/MWPW-169374)

**Test URLs:**
- Before: https://main--unity--adobecom.aem.page/?martech=off
- After: https://widgetunderline--unity--adobecom.aem.page/?martech=off
