### PR TITLE
[MWPW-169373] 'Download in app' text is not complete in jp locale

### DIFF
--- a/unitylibs/core/workflow/workflow-photoshop/widget.css
+++ b/unitylibs/core/workflow/workflow-photoshop/widget.css
@@ -106,15 +106,6 @@
 }
 
 @media screen and (max-width: 600px) {
-  .unity-enabled .interactive-area .unity-action-btn .btn-text {
-    max-width: 18ch;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
-    line-clamp: 3;
-    overflow: hidden;
-  }
-
   .unity-enabled .interactive-area .unity-option-area .changebg-options-tray {
     padding: 5px 5px 0;
     gap: 9px;


### PR DESCRIPTION
**Description:**
This PR removes the truncation CSS for the button texts on mobile.

TO NOTE: The truncation was implemented based on the indications from [this Figma design](https://www.figma.com/design/oWWjfZ4fpwt2jSfPxPVC2J/Interactive-Marquees-SSOT?node-id=3404-99657&t=4kXyQ8bP5Sry5hG1-0). We might not want to undo this, but in case we decide to, I’ve opened this PR so we can make the change quickly.

**Resolves:** [MWPW-169373](https://jira.corp.adobe.com/browse/MWPW-169373)

**Test URLs:**
Before: https://stage--unity--adobecom.hlx.page/drafts/rbogos/remove-background
After: https://mwpw-169373--unity--adobecom.hlx.page/drafts/rbogos/remove-background
