### PR TITLE
[MWPW-169793] Finalize API Exceptions

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -59,13 +59,17 @@ class ServiceHandler {
     try {
       const response = await fetch(url, options);
       const error = new Error();
-      const contentLength = response.headers.get('Content-Length');
+      const contentLength = response.headers.get('Content-Length') || '0';
       if (response.status !== 200) {
-        if (contentLength !== '0') {
-          const resJson = await response.json();
-          ['quotaexceeded', 'notentitled'].forEach((errorMessage) => {
-            if (resJson.reason?.includes(errorMessage)) error.message = errorMessage;
-          });
+        try {
+          if (contentLength !== '0') {
+            const resJson = await response.json();
+            ['quotaexceeded', 'notentitled'].forEach((errorMessage) => {
+              if (resJson.reason?.includes(errorMessage)) error.message = errorMessage;
+            });
+          }
+        } catch (jsonError) {
+          error.message = `Failed to parse JSON response. URL: ${url}, Options: ${JSON.stringify(options)}`;
         }
         if (!error.message) error.message = `Error fetching from service. URL: ${url}, Options: ${JSON.stringify(options)}`;
         error.status = response.status;
@@ -85,29 +89,25 @@ class ServiceHandler {
     }
   }
 
-  async fetchFromServiceWithRetry(url, options, timeLapsed = 0, maxRetryDelay = 120) {
+  async fetchFromServiceWithRetry(url, options, maxRetryDelay = 120) {
+    let timeLapsed = 0;
     try {
-      const response = await fetch(url, options);
-      const error = new Error();
-      const contentLength = response.headers.get('Content-Length');
-      if (response.status !== 200 && response.status !== 202) {
-        if (contentLength !== '0') {
-          const resJson = await response.json();
-          return resJson;
-        }
-        if (!error.message) error.message = `Error fetching from service. URL: ${url}, Options: ${JSON.stringify(options)}`;
-        error.status = response.status;
-        throw error;
-      } else if (response.status === 202) {
-        if (timeLapsed < maxRetryDelay && response.headers.get('retry-after')) {
-          const retryDelay = parseInt(response.headers.get('retry-after'));
-          await new Promise(resolve => setTimeout(resolve, retryDelay * 1000));
-          timeLapsed += retryDelay;
-          return this.fetchFromServiceWithRetry(url, options, timeLapsed, maxRetryDelay);
+      while (timeLapsed < maxRetryDelay) {
+        try {
+          return await this.fetchFromService(url, options);
+        } catch (error) {
+          if (error.status === 202 && error.response?.headers?.get('retry-after')) {
+            const retryDelay = parseInt(error.response.headers.get('retry-after')) || 5;
+            await new Promise(resolve => setTimeout(resolve, retryDelay * 1000));
+            timeLapsed += retryDelay;
+          } else {
+            throw error;
+          }
         }
       }
-      if (contentLength === '0') return {};
-      return await response.json();
+      const timeoutError = new Error(`Max retry delay exceeded for URL: ${url}`);
+      timeoutError.status = 504;
+      throw timeoutError;
     } catch (e) {
       if (['TimeoutError', 'AbortError'].includes(e.name)) {
         e.status = 504;


### PR DESCRIPTION
Refactor and fix potential issues in fetchFromService and fetchFromServiceWithRetry methods
There seems to be some issue with our fetchFromService and fetchFromServiceWithRetry functions. The fetchFromServiceWithRetry function could probably be simplified further as it is only used for the Finalize API today. Ensure we capture additional logging of 504 timeouts if maxRetryDelay is exceeded and 200 response still hasn't been returned.

<!-- Before submitting, please review all open PRs. -->

* Add your
* Specific
* Features or fixes

Resolves: [MWPW-169793](https://jira.corp.adobe.com/browse/MWPW-169793)

**Test URLs:**
- Before: https://main--unity--adobecom.aem.page/?martech=off
- After: https://MWPW-169793--unity--rohitsahu.aem.page/?martech=off
