### PR TITLE
[MWPW-169793] Finalize API Exceptions

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -20,6 +20,9 @@ class ServiceHandler {
     try {
       const response = await fetch(url, options);
       const contentLength = response.headers.get('Content-Length') || '0';
+      if (response.status === 202) {
+        return { response };
+      }
       if (response.status !== 200) {
         const error = new Error();
         if (contentLength !== '0') {

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -21,7 +21,7 @@ class ServiceHandler {
       const response = await fetch(url, options);
       const contentLength = response.headers.get('Content-Length') || '0';
       if (response.status === 202) {
-        return { response };
+        throw { response };
       }
       if (response.status !== 200) {
         const error = new Error();
@@ -65,7 +65,7 @@ class ServiceHandler {
         try {
           return await this.fetchFromService(url, options);
         } catch (error) {
-          if (error.status === 202 && error.response?.headers?.get('retry-after')) {
+          if (error.status === 202 && error.headers?.get('retry-after')) {
             const retryDelay = parseInt(error.response.headers.get('retry-after')) || 5;
             await new Promise(resolve => setTimeout(resolve, retryDelay * 1000));
             timeLapsed += retryDelay;

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -65,7 +65,7 @@ class ServiceHandler {
         try {
           return await this.fetchFromService(url, options);
         } catch (error) {
-          if (error.status === 202 && error.response?.headers?.get('retry-after')) {
+          if (error.response?.status === 202 && error.response?.headers?.get('retry-after')) {
             const retryDelay = parseInt(error.response.headers.get('retry-after')) || 5;
             await new Promise(resolve => setTimeout(resolve, retryDelay * 1000));
             timeLapsed += retryDelay;

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -47,7 +47,7 @@ class ServiceHandler {
     }
   }
 
-  handleSpecificErrors(responseJson) {
+  handleAssetSpecificErrors(responseJson) {
     const error = new Error();
     ['quotaexceeded', 'notentitled'].forEach((errorMessage) => {
       if (responseJson.reason?.includes(errorMessage)) error.message = errorMessage;

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -26,6 +26,9 @@ class ServiceHandler {
         if (contentLength !== '0') {
           try {
             error.responseJson = await response.json();
+            ['quotaexceeded', 'notentitled'].forEach((errorMessage) => {
+              if (resJson.reason?.includes(errorMessage)) error.message = errorMessage;
+            });
           } catch {
             error.message = `Failed to parse JSON response. URL: ${url}, Options: ${JSON.stringify(options)}`;
           }
@@ -91,14 +94,6 @@ class ServiceHandler {
     const queryString = new URLSearchParams(params).toString();
     const url = `${api}?${queryString}`;
     return this.fetchFromService(url, getOpts);
-  }
-
-  handleAssetSpecificErrors(responseJson) {
-    const error = new Error();
-    ['quotaexceeded', 'notentitled'].forEach((errorMessage) => {
-      if (responseJson.reason?.includes(errorMessage)) error.message = errorMessage;
-    });
-    return error.message ? error : null;
   }
 }
 

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -65,7 +65,7 @@ class ServiceHandler {
         try {
           return await this.fetchFromService(url, options);
         } catch (error) {
-          if (error.status === 202 && error.headers?.get('retry-after')) {
+          if (error.status === 202 && error.response?.headers?.get('retry-after')) {
             const retryDelay = parseInt(error.response.headers.get('retry-after')) || 5;
             await new Promise(resolve => setTimeout(resolve, retryDelay * 1000));
             timeLapsed += retryDelay;

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -31,7 +31,7 @@ export default class UploadHandler {
       { body: JSON.stringify(data) },
       { 'x-unity-dc-verb': this.actionBinder.MULTI_FILE ? `${this.actionBinder.workflowCfg.enabledFeatures[0]}MFU` : this.actionBinder.workflowCfg.enabledFeatures[0] },
     );
-    const specificError = this.serviceHandler.handleSpecificErrors(response);
+    const specificError = this.serviceHandler.handleAssetSpecificErrors(response);
     if (specificError) throw specificError;
     return response;
   }

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -26,14 +26,12 @@ export default class UploadHandler {
       ...(multifile && { multifile }),
       ...(workflowId && { workflowId }),
     };
-    const response = await this.serviceHandler.postCallToService(
+    assetData = await this.serviceHandler.postCallToService(
       this.actionBinder.acrobatApiConfig.acrobatEndpoint.createAsset,
       { body: JSON.stringify(data) },
       { 'x-unity-dc-verb': this.actionBinder.MULTI_FILE ? `${this.actionBinder.workflowCfg.enabledFeatures[0]}MFU` : this.actionBinder.workflowCfg.enabledFeatures[0] },
     );
-    const specificError = this.serviceHandler.handleAssetSpecificErrors(response);
-    if (specificError) throw specificError;
-    return response;
+    return assetData
   }
 
   async getBlobData(file) {

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -17,7 +17,6 @@ export default class UploadHandler {
   };
 
   async createAsset(file, multifile = false, workflowId = null) {
-    let assetData = null;
     const data = {
       surfaceId: unityConfig.surfaceId,
       targetProduct: this.actionBinder.workflowCfg.productName,
@@ -27,12 +26,14 @@ export default class UploadHandler {
       ...(multifile && { multifile }),
       ...(workflowId && { workflowId }),
     };
-    assetData = await this.serviceHandler.postCallToService(
+    const response = await this.serviceHandler.postCallToService(
       this.actionBinder.acrobatApiConfig.acrobatEndpoint.createAsset,
       { body: JSON.stringify(data) },
       { 'x-unity-dc-verb': this.actionBinder.MULTI_FILE ? `${this.actionBinder.workflowCfg.enabledFeatures[0]}MFU` : this.actionBinder.workflowCfg.enabledFeatures[0] },
     );
-    return assetData;
+    const specificError = this.serviceHandler.handleSpecificErrors(response);
+    if (specificError) throw specificError;
+    return response;
   }
 
   async getBlobData(file) {

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -17,6 +17,7 @@ export default class UploadHandler {
   };
 
   async createAsset(file, multifile = false, workflowId = null) {
+    let assetData = null;
     const data = {
       surfaceId: unityConfig.surfaceId,
       targetProduct: this.actionBinder.workflowCfg.productName,
@@ -31,7 +32,7 @@ export default class UploadHandler {
       { body: JSON.stringify(data) },
       { 'x-unity-dc-verb': this.actionBinder.MULTI_FILE ? `${this.actionBinder.workflowCfg.enabledFeatures[0]}MFU` : this.actionBinder.workflowCfg.enabledFeatures[0] },
     );
-    return assetData
+    return assetData;
   }
 
   async getBlobData(file) {


### PR DESCRIPTION
Refactor and fix potential issues in fetchFromService and fetchFromServiceWithRetry methods
There seems to be some issue with our fetchFromService and fetchFromServiceWithRetry functions. The 
- Ensured we capture additional logging of 504 timeouts if maxRetryDelay is exceeded and 200 response still hasn't been returned.
- Error has been captured to identify if the response parsing has failed
- Moved "quotaexceeded" and "notentitled" check outside the common fetch API
- fetchFromServiceWithRetry function has been be simplified to use the common fetchFromService method

Testing Notes:
- Sanitise network calls
- In extremely slow network, pdf upload should work fine. 

Resolves: [MWPW-169793](https://jira.corp.adobe.com/browse/MWPW-169793)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?martech=off
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?martech=off&&unitylibs=MWPW-169793