### PR TITLE
Transition screen cancel

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -152,6 +152,7 @@ export default class ActionBinder {
     this.LOADER_LIMIT = 95;
     this.MULTI_FILE = false;
     this.applySignedInSettings();
+    this.initActionListeners = this.initActionListeners.bind(this);
   }
 
   isSignedOut() {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Cancel button wasn't working after the modularization work and throwing a related console error.
This update fixes the cancel button seen on the transition screen. Clicking cancel will now stop the uploading process. 


**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?martech=off
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=transition-cancel&martech=off

Testing notes:

- Add a PDF to upload
- While the file is uploading click the cancel button.
- The uploading process should cancel and take you back to the initial upload screen.