### PR TITLE
[MWPW-169785] Workflow authoring enhancements to improve performance

### DIFF
--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -296,13 +296,11 @@ class WfInitiator {
 
   getEnabledFeatures() {
     const { supportedFeatures, supportedTexts } = this.workflowCfg;
-    
     const verbWidget = this.el.closest('.section')?.querySelector('.verb-widget');
     if (verbWidget) {
       const verb = [...verbWidget.classList].find(cn => supportedFeatures.has(cn));
       if (verb) this.workflowCfg.enabledFeatures.push(verb)
     }
-
     const configuredFeatures = this.el.querySelectorAll(':scope > div > div > ul > li > span.icon');
     configuredFeatures.forEach((cf) => {
       const cfName = [...cf.classList].find((cn) => cn.match('icon-'));

--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -296,13 +296,20 @@ class WfInitiator {
 
   getEnabledFeatures() {
     const { supportedFeatures, supportedTexts } = this.workflowCfg;
+    
+    const verbWidget = this.el.closest('.section')?.querySelector('.verb-widget');
+    if (verbWidget) {
+      const verb = [...verbWidget.classList].find(cn => supportedFeatures.has(cn));
+      if (verb) this.workflowCfg.enabledFeatures.push(verb)
+    }
+
     const configuredFeatures = this.el.querySelectorAll(':scope > div > div > ul > li > span.icon');
     configuredFeatures.forEach((cf) => {
       const cfName = [...cf.classList].find((cn) => cn.match('icon-'));
       if (!cfName) return;
       const fn = cfName.trim().replace('icon-', '');
       if (supportedFeatures.has(fn)) {
-        this.workflowCfg.enabledFeatures.push(fn);
+        if(!this.workflowCfg.enabledFeatures.includes(fn)) this.workflowCfg.enabledFeatures.push(fn);
         this.workflowCfg.featureCfg.push(cf.closest('li'));
       } else if (fn.includes('error')) {
         this.workflowCfg.errors[fn] = cf.closest('li').innerText;


### PR DESCRIPTION
### Description:
This PR removes the need for the icon expression used for the Unity workflow verb. Now, we’ll get the verb directly from the verb-widget block.
This has a dependency on [this DC PR](https://github.com/adobecom/dc/pull/1071). The DC PR needs to be merged first so this can be tested easily.

Resolves: [MWPW-169785](https://jira.corp.adobe.com/browse/MWPW-169785)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/drafts/rbogos/acrobat/compress-pdf-new?unitylibs=stage&martech=off
- After: https://stage--dc--adobecom.hlx.page/drafts/rbogos/acrobat/compress-pdf-new?unitylibs=mwpw-169785-performance&martech=off
