### PR TITLE
MWPW-170490 Avoid setting Content-Length to 0 if not present

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -29,7 +29,7 @@ class ServiceHandler {
   async fetchFromService(url, options) {
     try {
       const response = await fetch(url, options);
-      const contentLength = response.headers.get('Content-Length') || '0';
+      const contentLength = response.headers.get('Content-Length');
       if (response.status === 202) return { status: 202, headers: response.headers };
       if (response.status !== 200) {
         const error = new Error();


### PR DESCRIPTION
- Avoid settiing Content-Length to '0' if not present as response can be valid and not include this header
- Reverting this line update from https://github.com/adobecom/unity/pull/316

Resolves: [MWPW-170490](https://jira.corp.adobe.com/browse/MWPW-170490)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/test/pdf-editor?unitylibs=stage&martech=off
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/test/pdf-editor?unitylibs=MWPW-170490&martech=off
