### PR TITLE
MWPW-170525-Fix signed in allowed file type being added to signed out user

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -152,7 +152,7 @@ export default class ActionBinder {
   }
 
   acrobatSignedInSettings() {
-    if (this.limits.signedInallowedFileTypes) this.limits.allowedFileTypes.push(...this.limits.signedInallowedFileTypes);
+    if (this.limits.signedInallowedFileTypes && !this.signedOut) this.limits.allowedFileTypes.push(...this.limits.signedInallowedFileTypes);
   }
 
   async applySignedInSettings() {


### PR DESCRIPTION
* Fix signed in allowed file type being added to signed out user

Resolves: [MWPW-170525](https://jira.corp.adobe.com/browse/MWPW-170525)

**Test URLs:**
- Before: https://stage--dc--adobecom.aem.page/acrobat/online/split-pdf?unitylibs=stage?martech=off
- After: https://stage--dc--adobecom.aem.page/acrobat/online/split-pdf?unitylibs=filetype?martech=off
