### PR TITLE
Splashscreen.plain.html 404

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -193,19 +193,9 @@ export default class ActionBinder {
     if (this.workflowCfg.targetCfg.showSplashScreen) {
       parr.push(
         `${getUnityLibs()}/core/styles/splash-screen.css`,
-        `${this.splashFragmentLink}.plain.html`,
       );
     }
     await priorityLoad(parr);
-  }
-
-  async getAccountType() {
-    try {
-      return window.adobeIMS.getAccountType();
-    } catch (e) {
-      await this.dispatchErrorToast('verb_upload_error_generic', 500, `Exception raised when getting account type: ${e.message}`, true);
-      return '';
-    }
   }
 
   async dispatchErrorToast(code, status, info = null, lanaOnly = false, showError = true) {


### PR DESCRIPTION
- Fixes preloading of splashscreen causing 404.
- Removed duplicate calls to load splash screen
- Action-binder.js clean up

Resolves: Addressing comment made https://github.com/adobecom/unity/pull/314#issuecomment-2759066912

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=batch1b&martech=off
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=preload-fragment&martech=off

**Testing notes:**
- Open up the network tab in dev tools on before and after links.
- Notice splashscreen.plain.html being loaded (preloading)
- Select a file to upload. 
- Notice the 404 for "undefined.plain.html`
- Notice the a 404 for `undefined.plain.html`
- On After link run the same process.
- Notice no 404 and splashscreen.plain.html isn't loaded multiple times.


