### PR TITLE
[MWPW-170867]-[STAGE] Wait for event dispatched from DC acom code to redirect to acrobat web

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -477,6 +477,9 @@ export default class ActionBinder {
 
   async acrobatActionMaps(value, files, totalFileSize, eventName) {
     await this.handlePreloads();
+    window.addEventListener('DCUnity:RedirectReady', async (e) => {
+      await this.continueInApp();
+    });
     const uploadType = ActionBinder.LIMITS_MAP[this.workflowCfg.enabledFeatures[0]][0];
     switch (value) {
       case 'upload':
@@ -490,7 +493,7 @@ export default class ActionBinder {
       default:
         break;
     }
-    await this.continueInApp();
+    if(this.redirectWithoutUpload) await this.continueInApp();
   }
 
   extractFiles(e) {


### PR DESCRIPTION
* Wait for event dispatched from DC acom code to redirect to acrobat web
* The event is dispatched either on successfully sending the uploaded event to AA or after a timeout of 3 seconds

Resolves: [MWPW-170867](https://jira.corp.adobe.com/browse/MWPW-170867)

**Test URLs:**
- Before: https://stage--dc--adobecom.aem.page/acrobat/online/compress-pdf?unitylibs=stage
- After: https://stage--dc--adobecom.aem.page/acrobat/online/compress-pdf?unitylibs=MWPW-170867

Note: For reference here is the DC code to dispatch the event https://github.com/adobecom/dc/pull/1084/files

This PR is stage PR for below 2 hotfix PRs that will go to main tomorrow
https://github.com/adobecom/unity/pull/334
https://github.com/adobecom/unity/pull/340

**This is needed for validation on stage for hotfix release tomorrow. Once validation completed this PR will be reverted**
