### PR TITLE
MWPW-171173- Add analytics events

### DIFF
--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -94,7 +94,7 @@ export default class ActionBinder {
 
   async cancelUploadOperation() {
     try {
-      document.querySelector('a.con-button[href*="#_cancel"]').setAttribute('daa-ll', 'cancel');
+      sendAnalyticsEvent(new CustomEvent('Cancel|UnityWidget'));
       const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
       this.transitionScreen = new TransitionScreen(this.transitionScreen.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg);
       await this.transitionScreen.showSplashScreen();
@@ -273,6 +273,7 @@ export default class ActionBinder {
     }
     const objectUrl = URL.createObjectURL(file);
     await this.checkImageDimensions(objectUrl);
+    sendAnalyticsEvent(new CustomEvent('Uploading Started|UnityWidget'));
     const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
     this.transitionScreen = new TransitionScreen(this.transitionScreen.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg);
     await this.transitionScreen.showSplashScreen(true);
@@ -310,14 +311,15 @@ export default class ActionBinder {
         });
       },
       DIV: (el, key) => {
-        el.addEventListener('dragover', this.preventDefault);
-        el.addEventListener('dragenter', this.preventDefault);
         el.addEventListener('drop', async (e) => {
           sendAnalyticsEvent(new CustomEvent('Drag and drop|UnityWidget'));
           e.preventDefault();
           e.stopPropagation();
           const files = this.extractFiles(e);
           await this.photoshopActionMaps(actMap[key], files);
+        });
+        el.addEventListener('click', async (e) => {
+          sendAnalyticsEvent(new CustomEvent('Click Drag and drop|UnityWidget'));
         });
       },
       INPUT: (el, key) => {


### PR DESCRIPTION
* Add analytics event when clicked on drop zone to upload file
* Removed dragEvent as it is handled now in Upload code block
* Analytics event added for uploading started

Resolves: [MWPW-171173](https://jira.corp.adobe.com/browse/MWPW-171173)

**Test URLs:**
- Before: https://stage--cc--adobecom.aem.page/creativecloud/animation/testdoc/remove-background?unitylibs=stage&martech=off
- After: https://stage--cc--adobecom.aem.page/creativecloud/animation/testdoc/remove-background?unitylibs=MWPW-171173-analytics&martech=off


Note: this PR is copy of https://github.com/adobecom/unity/pull/341. Because of rebase done on stage reopening it again

