### PR TITLE
Improving payload + adding file metadata in cancel + dispatching success event on redirect

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -322,7 +322,7 @@ export default class UploadHandler {
         ...(isNonPdf ? { feedback: 'nonpdf' } : {}),
       },
     };
-    const redirectSuccess = await this.actionBinder.handleRedirect(cOpts);
+    const redirectSuccess = await this.actionBinder.handleRedirect(cOpts, fileData);
     if (!redirectSuccess) return;
     this.actionBinder.dispatchAnalyticsEvent('uploading', fileData);
     const uploadResult = await this.chunkPdf(
@@ -352,7 +352,7 @@ export default class UploadHandler {
       await this.transitionScreen.showSplashScreen(true);
       if (this.isNonPdf([file])) {
         await this.actionBinder.delay(3000);
-        const redirectSuccess = await this.actionBinder.handleRedirect(this.getGuestConnPayload('nonpdf'));
+        const redirectSuccess = await this.actionBinder.handleRedirect(this.getGuestConnPayload('nonpdf'), fileData);
         if (!redirectSuccess) return;
         this.actionBinder.redirectWithoutUpload = true;
         return;
@@ -418,7 +418,7 @@ export default class UploadHandler {
         workflowId,
       },
     };
-    const redirectSuccess = await this.actionBinder.handleRedirect(cOpts);
+    const redirectSuccess = await this.actionBinder.handleRedirect(cOpts, filesData);
     if (!redirectSuccess) return;
     this.actionBinder.dispatchAnalyticsEvent('uploading', filesData);
     const uploadResult = await this.chunkPdf(
@@ -452,7 +452,7 @@ export default class UploadHandler {
       await this.actionBinder.delay(3000);
       this.actionBinder.LOADER_LIMIT = 85;
       this.transitionScreen.updateProgressBar(this.actionBinder.transitionScreen.splashScreenEl, 85);
-      const redirectSuccess = await this.actionBinder.handleRedirect(this.getGuestConnPayload('multifile'));
+      const redirectSuccess = await this.actionBinder.handleRedirect(this.getGuestConnPayload('multifile'), filesData);
       if (!redirectSuccess) return;
       this.actionBinder.redirectWithoutUpload = true;
       return;

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -324,7 +324,8 @@ export default class UploadHandler {
     };
     const redirectSuccess = await this.actionBinder.handleRedirect(cOpts, fileData);
     if (!redirectSuccess) return;
-    this.actionBinder.dispatchAnalyticsEvent('uploading', fileData);
+    const errorData = {code: '-401', subCode: '106', desc: "Sample test message"}
+    this.actionBinder.dispatchAnalyticsEvent('uploading', {...fileData, errorData});
     const uploadResult = await this.chunkPdf(
       [assetData],
       [blobData],


### PR DESCRIPTION
Testing Notes:
1. Verify there is no break in redirect, success event should go on Redirect 
2. All evets fired are succesfully logged to splunk service
3. Event payloads include the fielsd as per the [wiki](https://wiki.corp.adobe.com/display/~arugupta/Proposal+for+Granular+Error+Tracking+in+Project+Unity+Upload+Workflows) 

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=stage
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=arugupta-dataPayloadForSplunk
