### PR TITLE
[MWPW-171722]Code to handle different text for desktop in transition screen

### DIFF
--- a/unitylibs/scripts/transition-screen.js
+++ b/unitylibs/scripts/transition-screen.js
@@ -3,16 +3,17 @@ import {
   localizeLink,
   loadImg,
   loadArea,
-} from '../scripts/utils.js';
+} from './utils.js';
 
 export default class TransitionScreen {
-  constructor(splashScreenEl, initActionListeners, loaderLimit, workflowCfg) {
+  constructor(splashScreenEl, initActionListeners, loaderLimit, workflowCfg, isDesktop = false) {
     this.splashScreenEl = splashScreenEl;
     this.initActionListeners = initActionListeners;
     this.LOADER_LIMIT = loaderLimit;
     this.workflowCfg = workflowCfg;
     this.LOADER_DELAY = 800;
     this.LOADER_INCREMENT = 30;
+    this.isDesktop = isDesktop;
   }
 
   updateProgressBar(layer, percentage) {
@@ -126,11 +127,25 @@ export default class TransitionScreen {
     this.splashScreenEl.parentElement?.classList.add('hide-splash-overflow');
   }
 
+  updateCopyForDevice() {
+    const headingElements = this.splashScreenEl.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    const mobileHeading = headingElements[1];
+    const desktopHeading = headingElements[2];
+    if (this.isDesktop && desktopHeading) {
+      if (mobileHeading) mobileHeading.style.display = 'none';
+      desktopHeading.style.display = 'block';
+    } else {
+      if (mobileHeading) mobileHeading.style.display = 'block';
+      if (desktopHeading) desktopHeading.style.display = 'none';
+    }
+  }
+
   async showSplashScreen(displayOn = false) {
     if (!this.splashScreenEl && !this.workflowCfg.targetCfg.showSplashScreen) return;
     if (this.splashScreenEl.classList.contains('decorate')) {
       if (this.splashScreenEl.querySelector('.icon-progress-bar')) await this.handleSplashProgressBar();
       if (this.splashScreenEl.querySelector('a.con-button[href*="#_cancel"]')) this.handleOperationCancel();
+      if (this.workflowCfg.productName.toLowerCase() === 'photoshop') this.updateCopyForDevice();
       this.splashScreenEl.classList.remove('decorate');
     }
     this.splashVisibilityController(displayOn);

--- a/unitylibs/scripts/transition-screen.js
+++ b/unitylibs/scripts/transition-screen.js
@@ -14,9 +14,6 @@ export default class TransitionScreen {
     this.LOADER_DELAY = 800;
     this.LOADER_INCREMENT = 30;
     this.isDesktop = isDesktop;
-    const [, mobileHeading, desktopHeading] = this.splashScreenEl.querySelectorAll('h1, h2, h3, h4, h5, h6');
-    this.mobileHeading = mobileHeading;
-    this.desktopHeading = desktopHeading;
   }
 
   updateProgressBar(layer, percentage) {
@@ -131,11 +128,14 @@ export default class TransitionScreen {
   }
 
   updateCopyForDevice() {
-    if (this.mobileHeading) {
-      this.mobileHeading.style.display = (this.isDesktop && this.desktopHeading) ? 'none' : 'block';
+    const headingElements = this.splashScreenEl.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    const mobileHeading = headingElements[1];
+    const desktopHeading = headingElements[2];
+    if (mobileHeading) {
+      mobileHeading.style.display = (this.isDesktop && desktopHeading) ? 'none' : 'block';
     }
-    if (this.desktopHeading) {
-      this.desktopHeading.style.display = (this.isDesktop && this.desktopHeading) ? 'block' : 'none';
+    if (desktopHeading) {
+      desktopHeading.style.display = (this.isDesktop && desktopHeading) ? 'block' : 'none';
     }
   }
 

--- a/unitylibs/scripts/transition-screen.js
+++ b/unitylibs/scripts/transition-screen.js
@@ -14,6 +14,9 @@ export default class TransitionScreen {
     this.LOADER_DELAY = 800;
     this.LOADER_INCREMENT = 30;
     this.isDesktop = isDesktop;
+    const [, mobileHeading, desktopHeading] = this.splashScreenEl.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    this.mobileHeading = mobileHeading;
+    this.desktopHeading = desktopHeading;
   }
 
   updateProgressBar(layer, percentage) {
@@ -128,15 +131,11 @@ export default class TransitionScreen {
   }
 
   updateCopyForDevice() {
-    const headingElements = this.splashScreenEl.querySelectorAll('h1, h2, h3, h4, h5, h6');
-    const mobileHeading = headingElements[1];
-    const desktopHeading = headingElements[2];
-    if (this.isDesktop && desktopHeading) {
-      if (mobileHeading) mobileHeading.style.display = 'none';
-      desktopHeading.style.display = 'block';
-    } else {
-      if (mobileHeading) mobileHeading.style.display = 'block';
-      if (desktopHeading) desktopHeading.style.display = 'none';
+    if (this.mobileHeading) {
+      this.mobileHeading.style.display = (this.isDesktop && this.desktopHeading) ? 'none' : 'block';
+    }
+    if (this.desktopHeading) {
+      this.desktopHeading.style.display = (this.isDesktop && this.desktopHeading) ? 'block' : 'none';
     }
   }
 


### PR DESCRIPTION
* Code to handle different text for desktop in transition screen

Resolves: [MWPW-171722](https://jira.corp.adobe.com/browse/MWPW-171722)

**Test URLs:**
Test pages to make sure nothing breaks on live experience
- Before: https://stage--cc--adobecom.hlx.page/products/photoshop/online?martech=off&unitylibs=stage
- After: https://stage--cc--adobecom.hlx.page/products/photoshop/online?martech=off&unitylibs=MWPW-171722

Test page to make sure if 2 different text is authored on transition screen fragment before CC phase code goes live doesn't break anything on live experience:
- Before: https://stage--cc--adobecom.hlx.page/products/photoshop/online?martech=off&unitylibs=stage
- After: https://stage--cc--adobecom.hlx.page/products/photoshop/online?martech=off&unitylibs=splash-test

splash-test feature branch points to a transition fragment which has the updated authoring with 2 different text. As part of this PR we need to test and make sure that there is no change in existing experience in both the scenarios when 2 different texts are authored or when only 1 test is authored in transition screen fragment.
