### PR TITLE
[MWPW-171794] Added retry for API calls

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -50,11 +50,13 @@ class ServiceHandler {
       return response.json();
     } catch (e) {
       if (e instanceof TypeError) {
-        e.status = 0;
-        e.message = `Network error. URL: ${url}`;
+        const error = new Error(`Network error. URL: ${url}; Error message: ${e.message}`);
+        error.status = 0;
+        throw error;
       } else if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-        e.status = 504;
-        e.message = `Request timed out. URL: ${url}`;
+        const error = new Error(`Request timed out. URL: ${url}; Error message: ${e.message}`);
+        error.status = 504;
+        throw error;
       }
       throw e;
     }
@@ -537,8 +539,7 @@ static ERROR_MAP = {
     await this.transitionScreen.showSplashScreen();
     this.redirectUrl = '';
     this.dispatchAnalyticsEvent('cancel', this.filesData);
-    const e = new Error();
-    e.message = 'Operation termination requested.';
+    const e = new Error('Operation termination requested.');
     e.showError = false;
     const cancelPromise = Promise.reject(e);
     this.promiseStack.unshift(cancelPromise);

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -29,7 +29,10 @@ class ServiceHandler {
       const response = await fetch(url, options);
       const contentLength = response.headers.get('Content-Length');
       if (response.status === 202) return { status: 202, headers: response.headers };
-      else if(canRetry && response.status >= 500 && response.status < 600) {  return this.fetchFromService(url, options, false); }
+      if(canRetry && response.status >= 500 && response.status < 600) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        return this.fetchFromService(url, options, false);
+     }
       if (response.status !== 200) {
         let errorMessage = `Error fetching from service. URL: ${url}`;
         if (contentLength !== '0') {

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -61,7 +61,7 @@ class ServiceHandler {
     }
   }
 
-  async fetchFromServiceWithRetry(url, options, maxRetryDelay = 150) {
+  async fetchFromServiceWithRetry(url, options, maxRetryDelay = 120) {
     let timeLapsed = 0;
     while (timeLapsed < maxRetryDelay) {
       const response = await this.fetchFromService(url, options, false);

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -27,7 +27,6 @@ class ServiceHandler {
   async fetchFromService(url, options, canRetry = true) {
     try {
       const response = await fetch(url, options);
-      var retry = options.retry;
       const contentLength = response.headers.get('Content-Length');
       if (response.status === 202) return { status: 202, headers: response.headers };
       else if(canRetry && response.status >= 500 && response.status < 600) {  return this.fetchFromService(url, options, false); }

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -88,11 +88,11 @@ export default class UploadHandler {
       return response;
     } catch (e) {
       if (e instanceof TypeError) {
-        e.message = `Network error. Asset ID: ${assetId}, ${blobData.size} bytes`;
-        await this.actionBinder.dispatchErrorToast('verb_upload_error_chunk_upload', 0, `Exception raised when uploading chunk to storage; ${e.message}`, true, true, {
+        const errorMessage = `Network error. Asset ID: ${assetId}, ${blobData.size} bytes`;
+        await this.actionBinder.dispatchErrorToast('verb_upload_error_chunk_upload', 0, `Exception raised when uploading chunk to storage; ${errorMessage}`, true, true, {
           code: 'verb_upload_error_chunk_upload',
           status: e.status || 0,
-          message: `Exception raised when uploading chunk to storage; ${e.message}`,
+          message: `Exception raised when uploading chunk to storage; ${errorMessage}`,
         });
       } else if (['Timeout', 'AbortError'].includes(e.name)) await this.actionBinder.dispatchErrorToast('verb_upload_error_chunk_upload', 504, `Timeout when uploading chunk to storage; ${assetId}, ${blobData.size} bytes`, true);
       throw e;

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -55,15 +55,15 @@ export default class UploadHandler {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
         try {
             const response = await this.uploadFileToUnity(url, blobData, fileType, assetId);
-            if (response.ok) {  return response; }
+            if (response.ok) return response;
         } catch (err) { error = err;}
         if (attempt < maxRetries) {
             await new Promise(resolve => setTimeout(resolve, retryDelay));
             retryDelay *= 2;
         }
     }
-    if (error) { error.message = error.message + ', Max retry delay exceeded during upload';
-    } else {  error = new Error('Max retry delay exceeded during upload');  }
+    if (error) error.message = error.message + ', Max retry delay exceeded during upload';
+    else error = new Error('Max retry delay exceeded during upload');
     throw error 
   }
 

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -49,7 +49,7 @@ export default class UploadHandler {
   }
 
   async uploadFileToUnityWithRetry(url, blobData, fileType, assetId) {
-    let retryDelay = 2000;
+    let retryDelay = 1000;
     const maxRetries = 3;
     let error = null;
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -62,7 +62,8 @@ export default class UploadHandler {
             retryDelay *= 2;
         }
     }
-    error.message = error.message + ', Max retry delay exceeded during upload';
+    if (error) { error.message = error.message + ', Max retry delay exceeded during upload';
+    } else {  error = new Error('Max retry delay exceeded during upload');  }
     throw error 
   }
 

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -88,7 +88,7 @@ export default class UploadHandler {
       return response;
     } catch (e) {
       if (e instanceof TypeError) {
-        const errorMessage = `Network error. Asset ID: ${assetId}, ${blobData.size} bytes`;
+        const errorMessage = `Network error. Asset ID: ${assetId}, ${blobData.size} bytes;  Error message: ${e.message}`;
         await this.actionBinder.dispatchErrorToast('verb_upload_error_chunk_upload', 0, `Exception raised when uploading chunk to storage; ${errorMessage}`, true, true, {
           code: 'verb_upload_error_chunk_upload',
           status: e.status || 0,


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Retry for Unity Service API failure for 5XX code
* Retry chunk upload errors with exponential backoff
* Fix "Exception thrown when verifying content: Cannot set property message of which has only a getter"

Resolves: [MWPW-171794](https://jira.corp.adobe.com/browse/MWPW-171794)
Also fixes:
- https://jira.corp.adobe.com/browse/MWPW-171795
- https://jira.corp.adobe.com/browse/MWPW-171796
- https://jira.corp.adobe.com/browse/MWPW-171801

**Test URLs:**
- Before: https://main--unity--adobecom.aem.page/?martech=off
- After: https://<branch>--unity--adobecom.aem.page/?martech=off
