### PR TITLE
Add upload success query parameter

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -186,7 +186,7 @@ static ERROR_MAP = {
     this.MULTI_FILE = false;
     this.applySignedInSettings();
     this.initActionListeners = this.initActionListeners.bind(this);
-    this.uploadSuccess = false;
+    this.uploadTimestamp = null;
   }
 
   isSignedOut() {
@@ -521,8 +521,7 @@ static ERROR_MAP = {
       if (this.multiFileFailure && this.redirectUrl.includes('#folder')) {
         window.location.href = `${this.redirectUrl}&feedback=${this.multiFileFailure}`;
       } else {
-        const redirectUrlUploadSuccess = `${this.redirectUrl}${this.redirectUrl.includes('?') ? '&' : '?'}uploadSuccess=${this.uploadSuccess}`;
-        window.location.href = redirectUrlUploadSuccess;
+        window.location.href = this.redirectWithoutUpload === false ? `${this.redirectUrl}${this.redirectUrl.includes('?') ? '&' : '?'}UTS_Uploaded=${this.uploadTimestamp}` : this.redirectUrl;
       }
     } catch (e) {
       await this.transitionScreen.showSplashScreen();

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -186,6 +186,7 @@ static ERROR_MAP = {
     this.MULTI_FILE = false;
     this.applySignedInSettings();
     this.initActionListeners = this.initActionListeners.bind(this);
+    this.uploadSuccess = false;
   }
 
   isSignedOut() {
@@ -519,7 +520,10 @@ static ERROR_MAP = {
       await this.delay(500);
       if (this.multiFileFailure && this.redirectUrl.includes('#folder')) {
         window.location.href = `${this.redirectUrl}&feedback=${this.multiFileFailure}`;
-      } else window.location.href = this.redirectUrl;
+      } else {
+        const redirectUrlUploadSuccess = `${this.redirectUrl}${this.redirectUrl.includes('?') ? '&' : '?'}uploadSuccess=${this.uploadSuccess}`;
+        window.location.href = redirectUrlUploadSuccess;
+      }
     } catch (e) {
       await this.transitionScreen.showSplashScreen();
       await this.dispatchErrorToast('verb_upload_error_generic', 500, `Exception thrown when redirecting to product; ${e.message}`, false, e.showError, {

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -392,7 +392,7 @@ export default class UploadHandler {
       const validated = await this.handleValidations(assetData);
       if (!validated) return;
     }
-    this.actionBinder.uploadSuccess = true;
+    this.actionBinder.uploadTimestamp = Date.now();
     this.actionBinder.dispatchAnalyticsEvent('uploaded', fileData);
   }
 
@@ -522,7 +522,7 @@ export default class UploadHandler {
       await this.dispatchGenericError(`Exception raised when uploading multiple files for a signed-in user; ${e.message}, Files data: ${JSON.stringify(filesData)}`, e.showError);
       return;
     }
-    this.actionBinder.uploadSuccess = true;
+    this.actionBinder.uploadTimestamp = Date.now();
     this.actionBinder.dispatchAnalyticsEvent('uploaded', filesData);
   }
 }

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -392,6 +392,7 @@ export default class UploadHandler {
       const validated = await this.handleValidations(assetData);
       if (!validated) return;
     }
+    this.actionBinder.uploadSuccess = true;
     this.actionBinder.dispatchAnalyticsEvent('uploaded', fileData);
   }
 
@@ -521,6 +522,7 @@ export default class UploadHandler {
       await this.dispatchGenericError(`Exception raised when uploading multiple files for a signed-in user; ${e.message}, Files data: ${JSON.stringify(filesData)}`, e.showError);
       return;
     }
+    this.actionBinder.uploadSuccess = true;
     this.actionBinder.dispatchAnalyticsEvent('uploaded', filesData);
   }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Adds `UTS_Uploaded` query param to the redirect url.
* If upload IS successful, `UTS_Uploaded=${this.uploadTimestamp}` is added to the end of the URL with the timestamp originating from the time of file upload.


Example URL with new query param:
`https://stage.acrobat.adobe.com/us/en/compress-pdf?x_api_client_id=unity&x_api_client_location=compress-pdf&user=frictionless_return_user&attempts=2%2B#assets=urn%3Aaaid%3Asc%3AUS%3A3f9a1c20-e9aa-31d6-8fc0-70d431897d85|ic-year-end-check-in-guide.pdf|8982279|application%2Fpdf&UTS_Uploaded=1745446585408`

Resolves: [MWPW-171687](https://jira.corp.adobe.com/browse/MWPW-171687)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?martech=off
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=upload-success-response&martech=off
