### PR TITLE
Segregate cancel events between pre uploading and post uploading

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -414,7 +414,6 @@ static ERROR_MAP = {
   }
 
   async handleSingleFileUpload(file, eventName) {
-    this.setWorkflowStep(WorkflowStep.UPLOADSTART);
     const sanitizedFileName = await this.sanitizeFileName(file.name); 
     const newFile = new File([file], sanitizedFileName, { type: file.type, lastModified: file.lastModified });
     this.filesData = { name: newFile.name, type: newFile.type, size: newFile.size, count: 1, uploadType: 'sfu'};
@@ -429,7 +428,6 @@ static ERROR_MAP = {
   async handleMultiFileUpload(files, totalFileSize, eventName) {
     this.MULTI_FILE = true;
     this.LOADER_LIMIT = 65;
-    this.workflowStep = WorkflowStep.UPLOADSTART;
     const isMixedFileTypes = this.isMixedFileTypes(files);
     this.filesData = { name: '', type: isMixedFileTypes, size: totalFileSize, count: files.length , uploadType: 'mfu'};
     this.dispatchAnalyticsEvent(eventName, this.filesData);

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -26,8 +26,7 @@ const STARTING_SPACE_PERIOD_REGEX = /^[ .]+/;
 export const WorkflowStep = {
   UPLOADSTART: "upload-start",
   UPLOADING: "uploading",
-  UPLOADED: "uploaded",
-  REDIRECT: "redirect"
+  NOTSTARTED: "not-started"
 };
 
 class ServiceHandler {
@@ -173,7 +172,7 @@ static ERROR_MAP = {
   constructor(unityEl, workflowCfg, wfblock, canvasArea, actionMap = {}) {
     this.unityEl = unityEl;
     this.workflowCfg = workflowCfg;
-    this.workflowStep = null;
+    this.workflowStep = WorkflowStep.NOTSTARTED;
     this.block = wfblock;
     this.canvasArea = canvasArea;
     this.actionMap = actionMap;
@@ -408,7 +407,6 @@ static ERROR_MAP = {
       cOpts.payload.newUser = true;
       cOpts.payload.attempts = '1st';
     }
-    console.log(this.workflowStep);
     await this.getRedirectUrl(cOpts);
     if (!this.redirectUrl) return false;
     this.dispatchAnalyticsEvent('redirectUrl', {...filesData, redirectUrl: this.redirectUrl});

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -239,6 +239,11 @@ static ERROR_MAP = {
     await priorityLoad(parr);
   }
 
+  setWorkflowStep(step) {
+    this.workflowStep = step;
+    console.log('Workflow step set to:', this.workflowStep);
+  }
+
   async dispatchErrorToast(errorType, status, info = null, lanaOnly = false, showError = true, errorMetaData = {}) {
     if (!showError) return;
     const errorMessage = errorType in this.workflowCfg.errors
@@ -403,6 +408,7 @@ static ERROR_MAP = {
       cOpts.payload.newUser = true;
       cOpts.payload.attempts = '1st';
     }
+    console.log(this.workflowStep);
     await this.getRedirectUrl(cOpts);
     if (!this.redirectUrl) return false;
     this.dispatchAnalyticsEvent('redirectUrl', {...filesData, redirectUrl: this.redirectUrl});
@@ -410,7 +416,7 @@ static ERROR_MAP = {
   }
 
   async handleSingleFileUpload(file, eventName) {
-    this.workflowStep = WorkflowStep.UPLOADSTART;
+    this.setWorkflowStep(WorkflowStep.UPLOADSTART);
     const sanitizedFileName = await this.sanitizeFileName(file.name); 
     const newFile = new File([file], sanitizedFileName, { type: file.type, lastModified: file.lastModified });
     this.filesData = { name: newFile.name, type: newFile.type, size: newFile.size, count: 1, uploadType: 'sfu'};

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -3,6 +3,7 @@
 /* eslint-disable no-restricted-syntax */
 
 import { unityConfig, getUnityLibs } from '../../../scripts/utils.js';
+import { WorkflowStep } from './action-binder.js';
 
 export default class UploadHandler {
   constructor(actionBinder, serviceHandler) {
@@ -374,6 +375,7 @@ export default class UploadHandler {
     };
     const redirectSuccess = await this.actionBinder.handleRedirect(cOpts, fileData);
     if (!redirectSuccess) return;
+    this.actionBinder.WorkflowStep = WorkflowStep.UPLOADING;
     this.actionBinder.dispatchAnalyticsEvent('uploading', fileData);
     const uploadResult = await this.chunkPdf(
       [assetData],
@@ -470,6 +472,7 @@ export default class UploadHandler {
     };
     const redirectSuccess = await this.actionBinder.handleRedirect(cOpts, filesData);
     if (!redirectSuccess) return;
+    this.actionBinder.WorkflowStep = WorkflowStep.UPLOADING;
     this.actionBinder.dispatchAnalyticsEvent('uploading', filesData);
     const uploadResult = await this.chunkPdf(
       assetDataArray,

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -350,6 +350,7 @@ export default class UploadHandler {
   }
 
   async uploadSingleFile(file, fileData, isNonPdf = false) {
+    this.actionBinder.setWorkflowStep(WorkflowStep.UPLOADSTART);
     const { maxConcurrentChunks } = this.getConcurrentLimits();
     let cOpts = {};
     const [blobData, assetData] = await Promise.all([
@@ -431,6 +432,7 @@ export default class UploadHandler {
   }
 
   async uploadMultiFile(files, filesData) {
+    this.actionBinder.setWorkflowStep(WorkflowStep.UPLOADSTART);
     const workflowId = crypto.randomUUID();
     const { maxConcurrentFiles, maxConcurrentChunks } = this.getConcurrentLimits();
     const blobDataArray = [];

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -373,10 +373,11 @@ export default class UploadHandler {
         ...(isNonPdf ? { feedback: 'nonpdf' } : {}),
       },
     };
+    this.actionBinder.setWorkflowStep(WorkflowStep.REDIRECT);
     const redirectSuccess = await this.actionBinder.handleRedirect(cOpts, fileData);
     if (!redirectSuccess) return;
-    this.actionBinder.WorkflowStep = WorkflowStep.UPLOADING;
     this.actionBinder.dispatchAnalyticsEvent('uploading', fileData);
+    this.actionBinder.setWorkflowStep(WorkflowStep.UPLOADING);
     const uploadResult = await this.chunkPdf(
       [assetData],
       [blobData],
@@ -472,8 +473,8 @@ export default class UploadHandler {
     };
     const redirectSuccess = await this.actionBinder.handleRedirect(cOpts, filesData);
     if (!redirectSuccess) return;
-    this.actionBinder.WorkflowStep = WorkflowStep.UPLOADING;
     this.actionBinder.dispatchAnalyticsEvent('uploading', filesData);
+    this.actionBinder.WorkflowStep = WorkflowStep.UPLOADING;
     const uploadResult = await this.chunkPdf(
       assetDataArray,
       blobDataArray,

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -373,7 +373,6 @@ export default class UploadHandler {
         ...(isNonPdf ? { feedback: 'nonpdf' } : {}),
       },
     };
-    this.actionBinder.setWorkflowStep(WorkflowStep.REDIRECT);
     const redirectSuccess = await this.actionBinder.handleRedirect(cOpts, fileData);
     if (!redirectSuccess) return;
     this.actionBinder.dispatchAnalyticsEvent('uploading', fileData);
@@ -474,7 +473,7 @@ export default class UploadHandler {
     const redirectSuccess = await this.actionBinder.handleRedirect(cOpts, filesData);
     if (!redirectSuccess) return;
     this.actionBinder.dispatchAnalyticsEvent('uploading', filesData);
-    this.actionBinder.WorkflowStep = WorkflowStep.UPLOADING;
+    this.actionBinder.setWorkflowStep(WorkflowStep.UPLOADING);
     const uploadResult = await this.chunkPdf(
       assetDataArray,
       blobDataArray,


### PR DESCRIPTION
Testing Notes:
1. Click cancel before uplaoding event is fired, verify the content.count=-2 in the splunk network call
2. Click cancel after uplaoding event is fired, verify the content.count=-3 in the splunk network call

Resolves: [MWPW-171665](https://jira.corp.adobe.com/browse/MWPW-171665)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=stage
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=cancelBifercation
