### PR TITLE
[MWPW-172032] fix transition screen exception on clicking cancel

### DIFF
--- a/unitylibs/scripts/transition-screen.js
+++ b/unitylibs/scripts/transition-screen.js
@@ -140,7 +140,7 @@ export default class TransitionScreen {
   }
 
   async showSplashScreen(displayOn = false) {
-    if (!this.splashScreenEl && !this.workflowCfg.targetCfg.showSplashScreen) return;
+    if (!this.splashScreenEl || !this.workflowCfg.targetCfg.showSplashScreen) return;
     if (this.splashScreenEl.classList.contains('decorate')) {
       if (this.splashScreenEl.querySelector('.icon-progress-bar')) await this.handleSplashProgressBar();
       if (this.splashScreenEl.querySelector('a.con-button[href*="#_cancel"]')) this.handleOperationCancel();


### PR DESCRIPTION
(cherry picked from commit ee494a1aae4e918c31165bad7631d98db5a87a76)

<!-- Before submitting, please review all open PRs. -->

The splashscreen null check logic for return was not correct, leading to exception in cases where we are transitioning to a different page or clicking on cancel. 

Resolves: [MWPW-172032](https://jira.corp.adobe.com/browse/MWPW-172032)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/test/pdf-to-word?
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/test/pdf-to-word?unitylibs=cancel-exception-fix
