### PR TITLE
[MWPW-172209] Send analytics to capture retry success for chunk upload

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -265,7 +265,7 @@ static ERROR_MAP = {
           metaData: this.filesData,
           errorData: {
             code: ActionBinder.ERROR_MAP[errorMetaData.code || errorType] || -1,
-            subCode: ActionBinder.ERROR_MAP[errorMetaData.subCode] || undefined,
+            subCode: ActionBinder.ERROR_MAP[errorMetaData.subCode] || errorMetaData.subCode,
             desc: errorMetaData.desc || message || undefined
           },
           sendToSplunk,

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -549,7 +549,7 @@ static ERROR_MAP = {
     await this.transitionScreen.showSplashScreen();
     this.redirectUrl = '';
     this.filesData = this.filesData || {};
-    this.filesData.workflowStep = this.isUploading ? "uploading" : "preuploading";
+    this.filesData.workflowStep = this.isUploading ? 'uploading' : 'preuploading';
     this.dispatchAnalyticsEvent('cancel', this.filesData);
     this.setIsUploading(false);
     const e = new Error('Operation termination requested.');

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -549,7 +549,7 @@ static ERROR_MAP = {
     await this.transitionScreen.showSplashScreen();
     this.redirectUrl = '';
     this.filesData = this.filesData || {};
-    this.filesData.count = this.isUploading ? -3 : -2;
+    this.filesData.workflowStep = this.isUploading ? "uploading" : "preuploading";
     this.dispatchAnalyticsEvent('cancel', this.filesData);
     this.setIsUploading(false);
     const e = new Error('Operation termination requested.');

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -57,7 +57,7 @@ export default class UploadHandler {
         const response = await this.uploadFileToUnity(url, blobData, fileType, assetId, chunkNumber);
         if (response.ok) {
           this.actionBinder.dispatchAnalyticsEvent('chunk_uploaded', {
-            chunkUploadAttempt: `${attempt}`,
+            chunkUploadAttempt: attempt,
             assetId,
             chunkNumber,
             size: `${blobData.size}`,
@@ -442,7 +442,7 @@ export default class UploadHandler {
       const validated = await this.handleValidations(assetData);
       if (!validated) return;
     }
-    this.actionBinder.dispatchAnalyticsEvent('uploaded', { ...fileData, assetId: assetData.id, chunkUploadAttempt: `${attemptMap.get(0)}` });
+    this.actionBinder.dispatchAnalyticsEvent('uploaded', { ...fileData, assetId: assetData.id, maxRetryCount: attemptMap.get(0) });
   }
 
   async singleFileGuestUpload(file, fileData) {

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -153,7 +153,7 @@ export default class UploadHandler {
         const url = assetData.uploadUrls[i];
         return async () => {
           if (fileUploadFailed) return Promise.resolve();
-          const urlObj = new URL(url);
+          const urlObj = new URL(url.href);
           const chunkNumber = urlObj.searchParams.get('partNumber') || 'unknown';
           try {
             const { attempt } = await this.uploadFileToUnityWithRetry(url.href, chunk, fileType, assetData.id, chunkNumber);

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -55,7 +55,15 @@ export default class UploadHandler {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
         try {
             const response = await this.uploadFileToUnity(url, blobData, fileType, assetId);
-            if (response.ok) return response;
+            if (response.ok) {
+              this.actionBinder.dispatchAnalyticsEvent('chunk_uploaded', {
+                attempt,
+                assetId,
+                size: blobData.size,
+                type: fileType,
+              });
+              return response;
+            }
         } catch (err) { error = err;}
         if (attempt < maxRetries) {
             await new Promise(resolve => setTimeout(resolve, retryDelay));

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -442,7 +442,7 @@ export default class UploadHandler {
       const validated = await this.handleValidations(assetData);
       if (!validated) return;
     }
-    this.actionBinder.dispatchAnalyticsEvent('uploaded', { ...fileData, chunkUploadAttempt: `${attemptMap.get(0)}` });
+    this.actionBinder.dispatchAnalyticsEvent('uploaded', { ...fileData, assetId: assetData.id, chunkUploadAttempt: `${attemptMap.get(0)}` });
   }
 
   async singleFileGuestUpload(file, fileData) {

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -48,7 +48,7 @@ export default class UploadHandler {
     return blob;
   }
 
-  async uploadFileToUnityWithRetry(url, blobData, fileType, assetId, chunkNumber = 'unknown') {
+  async uploadFileToUnityWithRetry(url, blobData, fileType, assetId, chunkNumber = 0) {
     let retryDelay = 1000;
     const maxRetries = 4;
     let error = null;
@@ -161,9 +161,9 @@ export default class UploadHandler {
         return async () => {
           if (fileUploadFailed) return Promise.resolve();
           const urlObj = new URL(url.href);
-          const chunkNumber = urlObj.searchParams.get('partNumber') || 'unknown';
+          const chunkNumber = urlObj.searchParams.get('partNumber') || 0;
           try {
-            const { attempt } = await this.uploadFileToUnityWithRetry(url.href, chunk, fileType, assetData.id, chunkNumber);
+            const { attempt } = await this.uploadFileToUnityWithRetry(url.href, chunk, fileType, assetData.id, parseInt(chunkNumber));
             if (attempt > maxAttempts) maxAttempts = attempt;
             attemptMap.set(fileIndex, maxAttempts);
           } catch {

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -57,7 +57,7 @@ export default class UploadHandler {
         const response = await this.uploadFileToUnity(url, blobData, fileType, assetId, chunkNumber);
         if (response.ok) {
           this.actionBinder.dispatchAnalyticsEvent('chunk_uploaded', {
-            attempt: `${attempt}`,
+            chunkUploadAttempt: `${attempt}`,
             assetId,
             chunkNumber,
             size: `${blobData.size}`,

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -89,8 +89,8 @@ export default class UploadHandler {
         error.status = response.status;
         await this.actionBinder.dispatchErrorToast('verb_upload_error_generic', response.status, `Failed when uploading chunk to storage; ${response.statusText}, ${assetId}, ${blobData.size} bytes`, true, true, {
           code: 'verb_upload_warn_chunk_upload',
-          subCode: response.status,
-          desc: `Failed when uploading chunk to storage; ${response.statusText}, ${assetId}, ${blobData.size} bytes; chunkNumber: ${chunkNumber}`,
+          subCode: chunkNumber,
+          desc: `Failed when uploading chunk to storage; ${response.statusText}, ${assetId}, ${blobData.size} bytes; status: ${response.status}`,
         });
         throw error;
       }
@@ -100,14 +100,20 @@ export default class UploadHandler {
         const errorMessage = `Network error. Asset ID: ${assetId}, ${blobData.size} bytes;  Error message: ${e.message}`;
         await this.actionBinder.dispatchErrorToast('verb_upload_error_generic', 0, `Exception raised when uploading chunk to storage; ${errorMessage}`, true, true, {
           code: 'verb_upload_warn_chunk_upload',
-          subCode: e.status || 0,
-          desc: `Exception raised when uploading chunk to storage; ${errorMessage}; chunkNumber: ${chunkNumber}`,
+          subCode: chunkNumber,
+          desc: `Exception raised when uploading chunk to storage; ${errorMessage}; status: ${e.status}`,
         });
       } else if (['Timeout', 'AbortError'].includes(e.name)) await this.actionBinder.dispatchErrorToast('verb_upload_error_generic', 504, `Timeout when uploading chunk to storage; ${assetId}, ${blobData.size} bytes`, true, true, {
         code: 'verb_upload_warn_chunk_upload',
-        subCode: e.status || 0,
-        desc: `Timeout when uploading chunk to storage; ${assetId}, ${blobData.size} bytes; chunkNumber: ${chunkNumber}`,
-      });
+        subCode: chunkNumber,
+        desc: `Timeout when uploading chunk to storage; ${assetId}, ${blobData.size} bytes; status: ${e.status}`,
+      }); else {
+        await this.actionBinder.dispatchErrorToast('verb_upload_error_generic', e.status || 500, `Exception raised when uploading chunk to storage; ${e.message}, ${assetId}, ${blobData.size} bytes`, true, true, {
+          code: 'verb_upload_warn_chunk_upload',
+          subCode: chunkNumber,
+          desc: `Exception raised when uploading chunk to storage; ${e.message}, ${assetId}, ${blobData.size} bytes; status: ${e.status}`,
+        });
+      }
       throw e;
     }
   }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Add analytics for chunk upload success to capture the chunk upload attempt. 
* Capture cancel step as uploading and preuploading

Corresponding Slytherin PR: https://github.com/adobecom/dc/pull/1140 

Resolves: [MWPW-172209](https://jira.corp.adobe.com/browse/MWPW-172209)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/test/pdf-to-word
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/test/pdf-to-word?unitylibs=chunk-upload-retry-analytics
