### PR TITLE
MWPW-172470 Preserve all A.com query params when redirecting to product

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -576,9 +576,11 @@ static ERROR_MAP = {
         });
       }
       await this.delay(500);
+      const [baseUrl, queryString] = this.redirectUrl.split('?');
+      const additionalParams = unityConfig.env === 'stage' ? `${window.location.search.slice(1)}&` : '';
       if (this.multiFileFailure && this.redirectUrl.includes('#folder')) {
-        window.location.href = `${this.redirectUrl}&feedback=${this.multiFileFailure}`;
-      } else window.location.href = this.redirectUrl;
+        window.location.href = `${baseUrl}?${additionalParams}feedback=${this.multiFileFailure}&${queryString}`;
+      } else window.location.href = `${baseUrl}?${additionalParams}${queryString}`;
     } catch (e) {
       await this.transitionScreen.showSplashScreen();
       await this.dispatchErrorToast('verb_upload_error_generic', 500, `Exception thrown when redirecting to product; ${e.message}`, false, e.showError, {

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -262,11 +262,13 @@ export const unityConfig = (() => {
     prod: {
       apiEndPoint: 'https://unity.adobe.io/api/v1',
       connectorApiEndPoint: 'https://unity.adobe.io/api/v1/asset/connector',
+      env: 'prod',
       ...commoncfg,
     },
     stage: {
       apiEndPoint: 'https://unity-stage.adobe.io/api/v1',
       connectorApiEndPoint: 'https://unity-stage.adobe.io/api/v1/asset/connector',
+      env: 'stage',
       ...commoncfg,
     },
   };


### PR DESCRIPTION
* Stage-specific request to retain all A.com query params post-upload and redirect to acrobat product

Resolves: [MWPW-172470](https://jira.corp.adobe.com/browse/MWPW-172470)

Testing Steps:
- Visit the "After" url
- Add additional query params and refresh the page
- Upload PDF(s) and verify that the same query params are passed to the product URL after successful upload

**Test URLs:**
- Before: https://stage--dc--adobecom.aem.page/acrobat/online/compress-pdf?unitylibs=stage
- After: https://stage--dc--adobecom.aem.page/acrobat/online/compress-pdf?unitylibs=MWPW-172470
