### PR TITLE
Adding upload success query parameter

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -205,6 +205,7 @@ static ERROR_MAP = {
     this.applySignedInSettings();
     this.initActionListeners = this.initActionListeners.bind(this);
     this.abortController = new AbortController();
+    this.uploadTimestamp = null;
   }
 
   isSignedOut() {
@@ -549,7 +550,7 @@ static ERROR_MAP = {
       const additionalParams = unityConfig.env === 'stage' ? `${window.location.search.slice(1)}&` : '';
       if (this.multiFileFailure && this.redirectUrl.includes('#folder')) {
         window.location.href = `${baseUrl}?${additionalParams}feedback=${this.multiFileFailure}&${queryString}`;
-      } else window.location.href = `${baseUrl}?${additionalParams}${queryString}`;
+      } else window.location.href = `${baseUrl}?${this.redirectWithoutUpload === false ? `UTS_Uploaded=${this.uploadTimestamp}&` : ''}${additionalParams}${queryString}`;
     } catch (e) {
       await this.transitionScreen.showSplashScreen();
       await this.dispatchErrorToast('verb_upload_error_generic', 500, `Exception thrown when redirecting to product; ${e.message}`, false, e.showError, {

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -460,6 +460,7 @@ export default class UploadHandler {
       const validated = await this.handleValidations(assetData);
       if (!validated) return;
     }
+    this.actionBinder.uploadTimestamp = Date.now();
     this.actionBinder.dispatchAnalyticsEvent('uploaded', { ...fileData, assetId: assetData.id, maxRetryCount: attemptMap.get(0) });
   }
 
@@ -592,6 +593,7 @@ export default class UploadHandler {
       await this.dispatchGenericError(`Exception raised when uploading multiple files for a signed-in user; ${e.message}, Files data: ${JSON.stringify(filesData)}`, e.showError);
       return;
     }
+    this.actionBinder.uploadTimestamp = Date.now();
     this.actionBinder.dispatchAnalyticsEvent('uploaded', filesData);
   }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Adds `UTS_Uploaded` query param to the redirect url.
* If upload IS successful, `UTS_Uploaded=${this.uploadTimestamp}` is added to the end of the URL with the timestamp originating from the time of file upload.

Example URL with new query param:
`hhttps://stage.acrobat.adobe.com/us/en/compress-pdf?UTS_Uploaded=1746577791179&unitylibs=upload-success-query-param&martech=off&x_api_client_id=unity&x_api_client_location=compress-pdf&user=frictionless_return_user&attempts=2%2B#assets=urn%3Aaaid%3Asc%3AUS%3Ab4b990e9-62d6-364d-b9dc-efcd1a98ebb3|ic-year-end-check-in-guide.pdf|8982279|application%2Fpdf`

Resolves: [MWPW-171687](https://jira.corp.adobe.com/browse/MWPW-171687)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?martech=off
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=upload-success-query-param&martech=off
