### PR TITLE
[MWPW-173471] Make Photoshop web redirect on desktop configurable through authoring

### DIFF
--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -343,8 +343,10 @@ export default class ActionBinder {
     await this.checkImageDimensions(objectUrl);
     sendAnalyticsEvent(new CustomEvent('Uploading Started|UnityWidget'));
     this.logAnalyticsinSplunk('Uploading Started|UnityWidget');
-    const { default: isDesktop } = await import(`${getUnityLibs()}/utils/device-detection.js`);
-    this.desktop = isDesktop();
+    if (this.workflowCfg.desktopFeature) {
+      const { default: isDesktop } = await import(`${getUnityLibs()}/utils/device-detection.js`);
+      this.desktop = isDesktop();
+    }
     const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
     this.transitionScreen = new TransitionScreen(this.transitionScreen.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg, this.desktop);
     await this.transitionScreen.showSplashScreen(true);

--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -343,7 +343,7 @@ export default class ActionBinder {
     await this.checkImageDimensions(objectUrl);
     sendAnalyticsEvent(new CustomEvent('Uploading Started|UnityWidget'));
     this.logAnalyticsinSplunk('Uploading Started|UnityWidget');
-    if (this.workflowCfg.desktopFeature) {
+    if (this.workflowCfg.pswFeature) {
       const { default: isDesktop } = await import(`${getUnityLibs()}/utils/device-detection.js`);
       this.desktop = isDesktop();
     }

--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -308,7 +308,7 @@ class WfInitiator {
       'workflow-upload': {
         productName: product,
         sfList: new Set([feature]),
-        psw: psw,
+        psw,
       },
     };
     if (!wfName || !workflowCfg[wfName]) return [];
@@ -320,7 +320,7 @@ class WfInitiator {
       featureCfg: [],
       errors: {},
       supportedTexts: workflowCfg[wfName]?.stList ?? null,
-      pswFeature: psw ? true : false,
+      pswFeature: !!psw,
     };
   }
 

--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -262,12 +262,12 @@ class WfInitiator {
     let wfName = '';
     let product = '';
     let feature = '';
-    let desktop = null;
+    let psw = null;
     [...this.el.classList].forEach((cn) => {
       if (cn.match('workflow-')) wfName = cn;
       if (cn.match('product-')) product = cn.replace('product-', '');
       if (cn.match('feature-')) feature = cn.replace('feature-', '');
-      if (cn.match('desktop-enabled')) desktop = cn;
+      if (cn.match('psw-enabled')) psw = cn;
     });
     const workflowCfg = {
       'workflow-photoshop': {
@@ -308,7 +308,7 @@ class WfInitiator {
       'workflow-upload': {
         productName: product,
         sfList: new Set([feature]),
-        desktop: desktop,
+        psw: psw,
       },
     };
     if (!wfName || !workflowCfg[wfName]) return [];
@@ -320,7 +320,7 @@ class WfInitiator {
       featureCfg: [],
       errors: {},
       supportedTexts: workflowCfg[wfName]?.stList ?? null,
-      desktopFeature: desktop ? true : false,
+      pswFeature: psw ? true : false,
     };
   }
 

--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -262,7 +262,7 @@ class WfInitiator {
     let wfName = '';
     let product = '';
     let feature = '';
-    let psw = null;
+    let psw = '';
     [...this.el.classList].forEach((cn) => {
       if (cn.match('workflow-')) wfName = cn;
       if (cn.match('product-')) product = cn.replace('product-', '');

--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -262,10 +262,12 @@ class WfInitiator {
     let wfName = '';
     let product = '';
     let feature = '';
+    let desktop = null;
     [...this.el.classList].forEach((cn) => {
       if (cn.match('workflow-')) wfName = cn;
       if (cn.match('product-')) product = cn.replace('product-', '');
       if (cn.match('feature-')) feature = cn.replace('feature-', '');
+      if (cn.match('desktop-enabled')) desktop = cn;
     });
     const workflowCfg = {
       'workflow-photoshop': {
@@ -306,6 +308,7 @@ class WfInitiator {
       'workflow-upload': {
         productName: product,
         sfList: new Set([feature]),
+        desktop: desktop,
       },
     };
     if (!wfName || !workflowCfg[wfName]) return [];
@@ -317,6 +320,7 @@ class WfInitiator {
       featureCfg: [],
       errors: {},
       supportedTexts: workflowCfg[wfName]?.stList ?? null,
+      desktopFeature: desktop ? true : false;
     };
   }
 

--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -320,7 +320,7 @@ class WfInitiator {
       featureCfg: [],
       errors: {},
       supportedTexts: workflowCfg[wfName]?.stList ?? null,
-      desktopFeature: desktop ? true : false;
+      desktopFeature: desktop ? true : false,
     };
   }
 


### PR DESCRIPTION
* Make Photoshop web redirect on desktop configurable through authoring

Resolves: [MWPW-173471](https://jira.corp.adobe.com/browse/MWPW-173471)

**Test URLs:**
Test Page without the token to enable Photoshop web redirect. All devices should redirect to prelude
- Before: https://stage--cc--adobecom.hlx.page/products/photoshop/online?unitylibs=stage
- After: https://stage--cc--adobecom.hlx.page/products/photoshop/online?unitylibs=desktop-optional

Test Page with token added to enable redirect to Photoshop web on desktop only.
- Before: https://main--cc--adobecom.hlx.page/drafts/ruchika/unity/upload-image1?unitylibs=stage
- After: https://main--cc--adobecom.hlx.page/drafts/ruchika/unity/upload-image1?unitylibs=desktop-optional
