### PR TITLE
MWPW173666 : Incase of input validation failures, no event goes not even choose file event.

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -466,9 +466,7 @@ export default class ActionBinder {
   }
 
   async handleSingleFileUpload(files) {
-    //this.filesData = { type: files[0].type, size: files[0].size, count: 1, uploadType: 'sfu' };
     this.filesData = {...this.filesData,uploadType: 'sfu'};
-    //this.dispatchAnalyticsEvent(eventName, this.filesData);
     if (this.signedOut) await this.uploadHandler.singleFileGuestUpload(files[0], this.filesData);
     else await this.uploadHandler.singleFileUserUpload(files[0], this.filesData);
   }
@@ -476,10 +474,7 @@ export default class ActionBinder {
   async handleMultiFileUpload(files) {
     this.MULTI_FILE = true;
     this.LOADER_LIMIT = 65;
-    //const isMixedFileTypes = this.isMixedFileTypes(files);
-    // this.filesData = { type: isMixedFileTypes, size: totalFileSize, count: files.length, uploadType: 'mfu' };
     this.filesData = {...this.filesData,uploadType: 'mfu'};
-    //this.dispatchAnalyticsEvent(eventName, this.filesData);
     this.dispatchAnalyticsEvent('multifile', this.filesData);
     if (this.signedOut) await this.uploadHandler.multiFileGuestUpload(this.filesData);
     else await this.uploadHandler.multiFileUserUpload(files, this.filesData);

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -465,26 +465,28 @@ export default class ActionBinder {
     return true;
   }
 
-  async handleSingleFileUpload(files, eventName) {
-    this.filesData = { type: files[0].type, size: files[0].size, count: 1, uploadType: 'sfu' };
-    this.dispatchAnalyticsEvent(eventName, this.filesData);
+  async handleSingleFileUpload(files) {
+    //this.filesData = { type: files[0].type, size: files[0].size, count: 1, uploadType: 'sfu' };
+    this.filesData = {...this.filesData,uploadType: 'sfu'};
+    //this.dispatchAnalyticsEvent(eventName, this.filesData);
     if (this.signedOut) await this.uploadHandler.singleFileGuestUpload(files[0], this.filesData);
     else await this.uploadHandler.singleFileUserUpload(files[0], this.filesData);
   }
 
-  async handleMultiFileUpload(files, eventName, totalFileSize) {
+  async handleMultiFileUpload(files) {
     this.MULTI_FILE = true;
     this.LOADER_LIMIT = 65;
-    const isMixedFileTypes = this.isMixedFileTypes(files);
-    this.filesData = { type: isMixedFileTypes, size: totalFileSize, count: files.length, uploadType: 'mfu' };
-    this.dispatchAnalyticsEvent(eventName, this.filesData);
+    //const isMixedFileTypes = this.isMixedFileTypes(files);
+    // this.filesData = { type: isMixedFileTypes, size: totalFileSize, count: files.length, uploadType: 'mfu' };
+    this.filesData = {...this.filesData,uploadType: 'mfu'};
+    //this.dispatchAnalyticsEvent(eventName, this.filesData);
     this.dispatchAnalyticsEvent('multifile', this.filesData);
     if (this.signedOut) await this.uploadHandler.multiFileGuestUpload(this.filesData);
     else await this.uploadHandler.multiFileUserUpload(files, this.filesData);
   }
 
-  async handleFileUpload(files, eventName, totalFileSize) {
-    const verbsWithoutFallback = this.workflowCfg.targetCfg.verbsWithoutMfuFallback;
+  async handleFileUpload(files) {
+    const verbsWithoutFallback = this.workflowCfg.targetCfg.verbsWithoutMfuToSfuFallback;
     const sanitizedFiles = await Promise.all(files.map(async (file) => {
       const sanitizedFileName = await this.sanitizeFileName(file.name);
       return new File([file], sanitizedFileName, { type: file.type, lastModified: file.lastModified });
@@ -494,9 +496,9 @@ export default class ActionBinder {
     const { default: UploadHandler } = await import(`${getUnityLibs()}/core/workflow/${this.workflowCfg.name}/upload-handler.js`);
     this.uploadHandler = new UploadHandler(this, this.serviceHandler);
     if (files.length === 1 || (validFiles.length === 1 && !verbsWithoutFallback.includes(this.workflowCfg.enabledFeatures[0]))) {
-      await this.handleSingleFileUpload(validFiles, eventName);
+      await this.handleSingleFileUpload(validFiles);
     } else {
-      await this.handleMultiFileUpload(validFiles, eventName, totalFileSize);
+      await this.handleMultiFileUpload(validFiles);
     }
   }
 
@@ -524,7 +526,7 @@ export default class ActionBinder {
     }
   }
 
-  async processSingleFile(files, eventName) {
+  async processSingleFile(files) {
     this.limits = await this.loadVerbLimits(this.workflowCfg.name, ActionBinder.LIMITS_MAP[this.workflowCfg.enabledFeatures[0]]);
     if (!this.limits || Object.keys(this.limits).length === 0) return;
     if (!files || files.length > this.limits.maxNumFiles) {
@@ -533,17 +535,17 @@ export default class ActionBinder {
     }
     const file = files[0];
     if (!file) return;
-    await this.handleFileUpload(files, eventName);
+    await this.handleFileUpload(files);
   }
 
-  async processHybrid(files, totalFileSize, eventName) {
+  async processHybrid(files) {
     if (!files) {
       await this.dispatchErrorToast('validation_error_only_accept_one_file');
       return;
     }
     this.limits = await this.loadVerbLimits(this.workflowCfg.name, ActionBinder.LIMITS_MAP[this.workflowCfg.enabledFeatures[0]]);
     if (!this.limits || Object.keys(this.limits).length === 0) return;
-    await this.handleFileUpload(files, eventName, totalFileSize);
+    await this.handleFileUpload(files);
   }
 
   delay(ms) {
@@ -591,6 +593,8 @@ export default class ActionBinder {
   }
 
   async acrobatActionMaps(value, files, totalFileSize, eventName) {
+    this.filesData = { type: this.isMixedFileTypes(files), size: totalFileSize, count: files.length, uploadType: files.length>1 ? 'mfu' : 'sfu' };
+    this.dispatchAnalyticsEvent(eventName, this.filesData);
     await this.handlePreloads();
     if (this.signedOut === undefined) {
       await this.dispatchErrorToast('pre_upload_error_fetching_access_token', 401, 'IMS access token could not be fetched', false, true, {
@@ -607,8 +611,8 @@ export default class ActionBinder {
     switch (value) {
       case 'upload':
         this.promiseStack = [];
-        if (uploadType === 'single') await this.processSingleFile(files, eventName);
-        else if (uploadType === 'hybrid') await this.processHybrid(files, totalFileSize, eventName);
+        if (uploadType === 'single') await this.processSingleFile(files);
+        else if (uploadType === 'hybrid') await this.processHybrid(files);
         break;
       case 'interrupt':
         await this.cancelAcrobatOperation();


### PR DESCRIPTION
This is duplicate of https://github.com/adobecom/unity/pull/423. Had to create new as the previous one was raised on stage changes. 

Resolves: [MWPW-173666](https://jira.corp.adobe.com/browse/MWPW-173666)

Test URLs:

Before: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=stage
After: https://stage--dc--adobecom.hlx.page/acrobat/online/compress-pdf?unitylibs=fix-MWPW-173666
