### PR TITLE
[MWPW-173836] Getting 'unable to process the request' for all kind of toast errors

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -195,6 +195,38 @@ export default class ActionBinder {
     warn_delete_asset: -603,
   };
 
+  static NEW_TO_OLD_ERROR_KEY_MAP = {
+    'error_generic': 'verb_upload_error_generic',
+    'pre_upload_error_loading_verb_limits': 'verb_upload_error_loading_verb_limits',
+    'pre_upload_error_empty_verb_limits': 'verb_upload_error_empty_verb_limits',
+    'pre_upload_error_renaming_file': 'verb_upload_error_renaming_file',
+    'pre_upload_error_fetch_redirect_url': 'verb_upload_error_fetch_redirect_url',
+    'validation_error_validate_files': 'verb_upload_error_validate_files',
+    'validation_error_unsupported_type': 'verb_upload_error_unsupported_type',
+    'validation_error_empty_file': 'verb_upload_error_empty_file',
+    'validation_error_file_too_large': 'verb_upload_error_file_too_large',
+    'validation_error_only_accept_one_file': 'verb_upload_error_only_accept_one_file',
+    'validation_error_file_same_type': 'verb_upload_error_file_same_type',
+    'validation_error_unsupported_type_multi': 'verb_upload_error_unsupported_type_multi',
+    'validation_error_empty_file_multi': 'verb_upload_error_empty_file_multi',
+    'validation_error_file_too_large_multi': 'verb_upload_error_file_too_large_multi',
+    'validation_error_multiple_invalid_files': 'verb_upload_error_multiple_invalid_files',
+    'validation_error_max_num_files': 'verb_upload_error_max_num_files',
+    'upload_validation_error_max_page_count': 'verb_upload_error_max_page_count',
+    'upload_validation_error_min_page_count': 'verb_upload_error_min_page_count',
+    'upload_validation_error_verify_page_count': 'verb_upload_error_verify_page_count',
+    'upload_validation_error_max_page_count_multi': 'verb_upload_error_max_page_count_multi',
+    'upload_validation_error_duplicate_asset': 'verb_upload_error_duplicate_asset',
+    'upload_error_max_quota_exceeded': 'verb_upload_error_max_quota_exceeded',
+    'upload_error_no_storage_provision': 'verb_upload_error_no_storage_provision',
+    'upload_error_chunk_upload': 'verb_upload_error_chunk_upload',
+    'upload_error_finalize_asset': 'verb_upload_error_finalize_asset',
+    'upload_error_redirect_to_app': 'verb_upload_error_redirect_to_app',
+    'upload_warn_chunk_upload': 'verb_upload_warn_chunk_upload',
+    'pre_upload_warn_renamed_invalid_file_name': 'verb_warn_renamed_invalid_file_name',
+    'warn_delete_asset': 'verb_upload_warn_delete_asset',
+  };
+
   constructor(unityEl, workflowCfg, wfblock, canvasArea, actionMap = {}) {
     this.unityEl = unityEl;
     this.workflowCfg = workflowCfg;
@@ -283,7 +315,8 @@ export default class ActionBinder {
       ? this.workflowCfg.errors[errorType]
       : await (async () => {
         const getError = (await import('../../../scripts/errors.js')).default;
-        return getError(this.workflowCfg.enabledFeatures[0], errorType);
+        const oldKey = ActionBinder.NEW_TO_OLD_ERROR_KEY_MAP[errorType] || errorType;
+        return getError(this.workflowCfg.enabledFeatures[0], oldKey);
       })();
     const message = lanaOnly ? '' : errorMessage || 'Unable to process the request';
     const sendToSplunk = this.workflowCfg.targetCfg.sendSplunkAnalytics;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

This was happening since the error code strings have been changed and the error sheet has not been updated yet
created old vs new error codes and use old error code while fetching the error string from error sheet. I have also added the fallback to use the new error code in case we decide to update the error sheet

Resolves: [MWPW-173836](https://jira.corp.adobe.com/browse/MWPW-173836)

**Test URLs:**
- Before: https://main--dc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=release-052225
- After: https://main--dc--adobecom.hlx.page/acrobat/online/sign-pdf?unitylibs=revert-error-msg
