### PR TITLE
Accessiblity updates

### DIFF
--- a/unitylibs/core/workflow/workflow-firefly/widget.css
+++ b/unitylibs/core/workflow/workflow-firefly/widget.css
@@ -69,6 +69,10 @@
   width: 100%;
 }
 
+.unity-enabled .interactive-area .alert-holder .alert-toast .alert-content .alert-text {
+  width: auto;
+}
+
 .unity-enabled .interactive-area .alert-holder .alert-toast .alert-content .alert-text p {
   padding-top: 0;
 }
@@ -511,7 +515,7 @@
 .unity-enabled .interactive-area .verbs-container {
   display: flex;
   flex-wrap: wrap;
-  border-right: 1px solid #B8B5B9;
+  border-right: 1px solid rgb(0 0 0 / 9%);
   width: 144px;
   height: 70px;
   justify-content: flex-start;
@@ -554,6 +558,7 @@
   padding: 18px;
   list-style: none;
   background: #fff;
+  box-shadow: 0 0 10px #0000001c;
   border-radius: 10px;
   color: #292929;
   margin: 8px 0 0;
@@ -623,6 +628,11 @@
     left: 0;
     width: 100%;
     transform: translateY(70px);
+  }
+
+  .unity-enabled .interactive-area .ex-unity-wrap .alert-holder {
+    transform: translateY(-80%);
+    bottom: 0;
   }
 }
 
@@ -702,5 +712,9 @@
 
   .unity-enabled .interactive-area .verbs-container.show-menu .verb-list {
     width: 140px;
+  }
+
+  .unity-enabled .interactive-area .ex-unity-wrap .alert-holder {
+    transform: translateY(-90%);
   }
 }

--- a/unitylibs/core/workflow/workflow-firefly/widget.js
+++ b/unitylibs/core/workflow/workflow-firefly/widget.js
@@ -93,16 +93,20 @@ export default class UnityWidget {
       e.stopPropagation();
       verbList.querySelectorAll('.verb-link').forEach((listLink) => {
         listLink.parentElement.classList.remove('selected');
+        listLink.parentElement.removeAttribute('aria-label');
       });
       selectedElement.parentElement.classList.toggle('show-menu');
       selectedElement.setAttribute('aria-expanded', selectedElement.parentElement.classList.contains('show-menu') ? 'true' : 'false');
       link.parentElement.classList.add('selected');
       const copiedNodes = link.cloneNode(true).childNodes;
       copiedNodes[0].remove();
-      selectedElement.replaceChildren(...copiedNodes, menuIcon);
-      selectedElement.dataset.selectedVerb = link.getAttribute('data-verb-type');
-      this.updateDropdownForVerb(link.getAttribute('data-verb-type'));
       this.selectedVerbType = link.getAttribute('data-verb-type');
+      selectedElement.replaceChildren(...copiedNodes, menuIcon);
+      selectedElement.dataset.selectedVerb = this.selectedVerbType;
+      selectedElement.setAttribute('aria-label', `${this.selectedVerbType} prompt type selected`);
+      selectedElement.focus();
+      link.parentElement.setAttribute('aria-label', `${this.selectedVerbType} prompt type selected`);
+      this.updateDropdownForVerb(this.selectedVerbType);
       this.widgetWrap.setAttribute('data-selected-verb', this.selectedVerbType);
       this.updateAnalytics(this.selectedVerbType);
     };
@@ -117,6 +121,7 @@ export default class UnityWidget {
       class: 'selected-verb',
       'aria-expanded': 'false',
       'aria-controls': 'prompt-menu',
+      'aria-label': `${selectedVerbType} prompt type selected`,
       'data-selected-verb': selectedVerbType,
     }, `<img src="${href}" alt="" />${selectedVerbType}`);
     this.selectedVerbType = selectedVerbType;
@@ -147,6 +152,10 @@ export default class UnityWidget {
         this.hidePromptDropdown();
         this.showVerbMenu(selectedElement);
       }
+      if (e.key === 'Escape' || e.code === 27) {
+        selectedElement.parentElement.classList?.remove('show-menu');
+        selectedElement.focus();
+      }
     });
     verbs.forEach((verb, idx) => {
       const name = verb.nextElementSibling?.textContent.trim();
@@ -159,7 +168,10 @@ export default class UnityWidget {
         class: 'verb-link',
         'data-verb-type': verbType,
       }, `<img src="${icon}" alt="" />${name}`);
-      if (idx === 0) item.classList.add('selected');
+      if (idx === 0) {
+        item.classList.add('selected');
+        item.setAttribute('aria-label', `${verbType} prompt type selected`);
+      }
       verbs[0].classList.add('selected');
       link.prepend(selectedIcon);
       item.append(link);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Added aria-labels to selectedVerb button.
* Added aria-label to dropdown selected item.
* Escape key can now close the verbDropdown menu when open.
* Adjust styling of toast error for smaller screens cutting off close button.
* Adjust styling for prompt UI on light backgrounds.

Resolves: [MWPW-172411](https://jira.corp.adobe.com/browse/MWPW-172411)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/ruchika/unity/firefly/unity-firefly?unitylibs=firefly-workflow&martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/ruchika/unity/firefly/unity-firefly?unitylibs=ff-verb-dd-accessibility&martech=off
