### PR TITLE
Mobile prompt truncated to one line

### DIFF
--- a/unitylibs/core/workflow/workflow-firefly/widget.css
+++ b/unitylibs/core/workflow/workflow-firefly/widget.css
@@ -410,6 +410,7 @@
   display: inline-block;
   width: 20px;
   height: 20px;
+  flex: 0 0 auto;
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .drop-title-con.dynamic .refresh-btn svg {
@@ -675,7 +676,7 @@
   .hero-marquee.unity-enabled p {
     font-size: var(--type-body-s-size);
     line-height: var(--type-body-s-lh);
-  }   
+  }
 
   .hero-marquee.unity-enabled .interactive-area .ex-unity-wrap.sticky {
     bottom: 16px;
@@ -716,5 +717,16 @@
 
   .unity-enabled .interactive-area .ex-unity-wrap .alert-holder {
     transform: translateY(-90%);
+  }
+
+  .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .drop .drop-item svg {
+    transform: translateY(20%);
+  }
+
+  .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .drop .drop-item {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Mobile suggested prompts are updated to display only one line (max-viewport 599px).
* Prompt suggestions icon size doesn't change.

Resolves: [MWPW-174049](https://jira.corp.adobe.com/browse/MWPW-174049)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/rclayton/firefly/text-to-image?unitylibs=stage&martech=off
- After: https://main--cc--adobecom.aem.page/drafts/rclayton/firefly/text-to-image?unitylibs=ff-prompt-mobile-clamp&martech=off
