### PR TITLE
MWPW-174131 : Unable to upload on stage A.com page if user is already signed in

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -508,7 +508,7 @@ export default class UploadHandler {
     this.transitionScreen = new TransitionScreen(this.actionBinder.transitionScreen.splashScreenEl, this.actionBinder.initActionListeners, this.actionBinder.LOADER_LIMIT, this.actionBinder.workflowCfg);
     try {
       await this.transitionScreen.showSplashScreen(true);
-      await this.uploadSingleFile(file, fileData, !this.isPdf(file));
+      await this.uploadSingleFile(file, fileData, this.isPdf(file));
     } catch (e) {
       await this.transitionScreen.showSplashScreen();
       this.actionBinder.operations = [];


### PR DESCRIPTION
!isPdf() was being incorrectly sent instead of isPdf. Fixed now
Testing Notes: 
1. Check file upload for verbs that support single file pdf-only --- signed in user
2. Check for verbs that support non pdf - sfu and mfu --- signed in user

Resolves: [MWPW-174131](https://jira.corp.adobe.com/browse/MWPW-174131)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/merge-pdf?unitylibs=stage
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/merge-pdf?unitylibs=MWPW-174131
