### PR TITLE
[MWPW-174158][NALA] Update PDF Editor verbCopy text

### DIFF
--- a/nala/features/pdf-editor/pdf-editor.spec.cjs
+++ b/nala/features/pdf-editor/pdf-editor.spec.cjs
@@ -8,7 +8,7 @@ module.exports = {
       data: {
         verbTitle: 'Adobe Acrobat',
         verbHeading: 'Edit a PDF',
-        verbCopy: 'Make changes fast with Acrobat’s free online PDF editor. Edit text, add comments, fill & sign. Easy to use and secure.',
+        verbCopy: 'Make changes fast with the free online PDF editor in Acrobat. Edit text, add comments, and fill and sign documents with secure, easy to use tools.',
       },
       tags: '@pdf-editor @smoke @regression @unity',
     },


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* The text for `verbCopy` text has been updated in the placeholder sheet for the PDF Editor.

This PR updates the corresponding test accordingly.

Resolves: [MWPW-174158](https://jira.corp.adobe.com/browse/MWPW-174158)

**Test URLs:**
- Before: https://main--unity--adobecom.aem.page/?martech=off
- After: https://update-pdfeditor--unity--adobecom.aem.page/?martech=off
