### PR TITLE
MWPW-174834 Replace MIME types validation with file extensions

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/limits.json
+++ b/unitylibs/core/workflow/workflow-acrobat/limits.json
@@ -2,7 +2,7 @@
   "single": {
     "uploadType": "single",
     "maxNumFiles": 1,
-    "allowedFileTypes": ["application/pdf"],
+    "allowedFileTypes": ["pdf"],
     "maxFileSize": 104857600
   },
   "hybrid": {
@@ -16,27 +16,27 @@
   },
   "signedInallowedFileTypes": {
     "signedInallowedFileTypes": [
-      "application/msword",
-      "application/xml",
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "application/vnd.ms-powerpoint",
-      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "application/x-tika-ooxml",
-      "application/vnd.ms-excel",
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      "application/x-tika-msworks-spreadsheet",
-      "application/vnd.adobe.form.fillsign",
-      "application/illustrator",
-      "application/rtf",
-      "application/x-indesign",
-      "image/jpeg",
-      "image/png",
-      "image/bmp",
-      "image/gif",
-      "image/vnd.adobe.photoshop",
-      "image/tiff",
-      "message/rfc822",
-      "text/plain"
+      "doc",
+      "xml",
+      "docx",
+      "ppt",
+      "pptx",
+      "xlsx",
+      "xls",
+      "form",
+      "ai",
+      "rtf",
+      "indd",
+      "jpg",
+      "jpeg",
+      "png",
+      "bmp",
+      "gif",
+      "psd",
+      "tif",
+      "tiff",
+      "txt",
+      "text"
     ]
   },
   "page-limit-100": {
@@ -81,43 +81,65 @@
     "maxNumFiles": 100
   },
   "allowed-filetypes-pdf-only": {
-    "allowedFileTypes": ["application/pdf"]
+    "allowedFileTypes": ["pdf"]
   },
   "allowed-filetypes-all": {
     "allowedFileTypes": [
-      "application/pdf",
-      "application/msword",
-      "application/xml",
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "application/vnd.ms-powerpoint",
-      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "application/x-tika-ooxml",
-      "application/vnd.ms-excel",
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      "application/x-tika-msworks-spreadsheet",
-      "application/vnd.adobe.form.fillsign",
-      "application/illustrator",
-      "application/rtf",
-      "application/x-indesign",
-      "image/jpeg",
-      "image/png",
-      "image/bmp",
-      "image/gif",
-      "image/vnd.adobe.photoshop",
-      "image/tiff",
-      "message/rfc822",
-      "text/plain"
+      "pdf",
+      "doc",
+      "xml",
+      "docx",
+      "ppt",
+      "pptx",
+      "xlsx",
+      "xls",
+      "form",
+      "ai",
+      "rtf",
+      "indd",
+      "jpg",
+      "jpeg",
+      "png",
+      "bmp",
+      "gif",
+      "psd",
+      "tif",
+      "tiff",
+      "txt",
+      "text"
+    ]
+  },
+  "allowed-filetypes-pdf-word-excel-ppt-img-txt": {
+    "allowedFileTypes": [
+      "pdf",
+      "doc",
+      "docx",
+      "xls",
+      "xlsx",
+      "ppt",
+      "pptx",
+      "jpg",
+      "jpeg",
+      "png",
+      "bmp",
+      "gif",
+      "tif",
+      "tiff",
+      "txt",
+      "text",
+      "rtf"
     ]
   },
   "allowed-filetypes-pdf-word-ppt-txt": {
     "allowedFileTypes": [
-      "application/pdf",
-      "application/msword",
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "application/vnd.ms-powerpoint",
-      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "text/plain",
-      "application/rtf"
+      "pdf",
+      "doc",
+      "docx",
+      "ppt",
+      "pptx",
+      "txt",
+      "text",
+      "rtf"
     ]
   }
 }


### PR DESCRIPTION
* Replace client-side validation for file MIME types with file extensions

Resolves: [MWPW-174834](https://jira.corp.adobe.com/browse/MWPW-174834)

**Test URLs:**
- Before: [https://stage--dc--adobecom.hlx.live/acrobat/online/test/convert-pdf?unitylibs=stage](https://stage--dc--adobecom.hlx.live/acrobat/online/test/convert-pdf?unitylibs=stage)
- After: [https://stage--dc--adobecom.hlx.live/acrobat/online/test/convert-pdf?unitylibs=MWPW-174834
](https://stage--dc--adobecom.hlx.live/acrobat/online/test/convert-pdf?unitylibs=MWPW-174834
)