### PR TITLE
Fix for workflow getting stuck at transition screen if asset api fails 

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -420,6 +420,8 @@ export default class UploadHandler {
         this.createAsset(file),
       ]);
     } catch (error) {
+      this.initSplashScreen();
+      await this.transitionScreen.showSplashScreen();
       this.handleUploadError(error, 'pre_upload_error_create_asset');
       return;
     }


### PR DESCRIPTION
Added the logic to hide transition screen if asset api fails. This was just missing for asset api. Was already in place for connector and finalise apis.

Resolves: [MWPW-174798](https://jira.corp.adobe.com/browse/MWPW-174798)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.page/acrobat/online/rotate-pdf?unitylibs=stage
- After: https://stage--dc--adobecom.hlx.page/acrobat/online/rotate-pdf?unitylibs=MWPW-174798-500
