### PR TITLE
[MWPW-174834] Added pdf file support in ocr. Was a miss from the last PR.

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/limits.json
+++ b/unitylibs/core/workflow/workflow-acrobat/limits.json
@@ -134,6 +134,7 @@
   },
   "allowed-filetypes-pdf-word-excel-ppt-img-txt": {
     "allowedFileTypes": [
+      "application/pdf",
       "application/msword",
       "application/xml",
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document",


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Fixing injection caused by https://github.com/adobecom/unity/pull/480/files 

Resolves: [MWPW-174834](https://jira.corp.adobe.com/browse/MWPW-174834)

**Test URLs:**
- Before: https://stage--dc--adobecom.hlx.live/acrobat/online/test/convert-pdf?unitylibs=stage
- After: https://stage--dc--adobecom.hlx.live/acrobat/online/test/convert-pdf?unitylibs=MWPW-174834-3
