### PR TITLE
Update query to always get input value

### DIFF
--- a/unitylibs/core/workflow/workflow-firefly/action-binder.js
+++ b/unitylibs/core/workflow/workflow-firefly/action-binder.js
@@ -237,8 +237,8 @@ export default class ActionBinder {
 
   getSelectedVerbType = () => this.widgetWrap.getAttribute('data-selected-verb');
 
-  validateInput() {
-    if (this.inputField.value.length > 750) {
+  validateInput(query) {
+    if (query.length > 750) {
       this.serviceHandler.showErrorToast({ errorToastEl: this.errorToastEl, errorType: '.icon-error-max-length' }, 'Max prompt characters exceeded');
       return { isValid: false, errorCode: 'max-prompt-characters-exceeded' };
     }
@@ -271,12 +271,12 @@ export default class ActionBinder {
         if (key && value) queryParams[key] = value;
       });
     }
-    if (!this.query) this.query = this.inputField.value.trim();
+    this.query = this.inputField.value.trim();
     const selectedVerbType = `text-to-${this.getSelectedVerbType()}`;
     const action = (this.id ? 'prompt-suggestion' : 'generate');
     const eventData = { assetId: this.id, verb: selectedVerbType, action };
     this.logAnalytics('generate', eventData, { workflowStep: 'start' });
-    const validation = this.validateInput();
+    const validation = this.validateInput(this.query);
     if (!validation.isValid) {
       this.logAnalytics('generate', { ...eventData, errorData: { code: validation.errorCode } }, { workflowStep: 'complete', statusCode: -1 });
       return;
@@ -300,6 +300,7 @@ export default class ActionBinder {
       this.resetDropdown();
       if (url) window.location.href = url;
     } catch (err) {
+      this.query = '';
       this.serviceHandler.showErrorToast({ errorToastEl: this.errorToastEl, errorType: '.icon-error-request' }, err);
       this.logAnalytics('generate', {
         ...eventData,


### PR DESCRIPTION
Fixes issue where after entering too many characters into the prompt and getting the max-characters error toast, the user can not submit a new prompt with out refreshing the page.

* Updated `validateInput` function to compare `query` instead of input to keep toast errors in sync.
* Clear `query` in catch statement

Resolves: [MWPW-176278](https://jira.corp.adobe.com/browse/MWPW-176278)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/products/firefly/features/ai-video-generator?martech=off
- After: https://main--cc--adobecom.aem.live/products/firefly/features/ai-video-generator?unitylibs=unable-to-process-toast&martech=off
