### PR TITLE
[MWPW-17429] Add decision scope Params to the target fetch call

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -366,11 +366,20 @@ export default class ActionBinder {
 
   async fetchTargetResponse() {
     const decisionScopes = ['ACOM_UNITY_ACROBAT_EDITPDF_POC'];
+    const decisionScopeParams = {
+      countryCode: 'US',
+      firstTimeUser: false,
+      isTrialUser: false,
+      language: 'en-US',
+      subscriptionLevel: '',
+      subscriptionName: '',
+      userRole: '',
+    };
     try {
       // eslint-disable-next-line no-underscore-dangle
       window._satellite.track('propositionFetch', {
         decisionScopes,
-        data: { },
+        data: { __adobe: { target: decisionScopeParams } },
         done: (TargetPropositionResult, error) => {
           if (error) {
             return;

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -20,6 +20,6 @@
     "nonpdfSfuProductScreen": ["word-to-pdf", "jpg-to-pdf", "ppt-to-pdf", "excel-to-pdf", "png-to-pdf", "createpdf", "chat-pdf", "chat-pdf-student"],
     "mfuUploadAllowed": ["combine-pdf", "rotate-pages", "chat-pdf", "chat-pdf-student"],
     "mfuUploadOnlyPdfAllowed": ["combine-pdf"],
-    "experimentationOn": ["number-pages"]
+    "experimentationOn": ["add-comment"]
   }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

This is a follow up to PR https://github.com/adobecom/unity/pull/506/files 
AJO call was not working maybe because we are not providing the decisionscope params

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-17429)

**Test URLs:**
- Before: https://stage--dc--adobecom.aem.page/acrobat/online/compress-pdf
- After: https://stage--dc--adobecom.aem.page/acrobat/online/compress-pdf?unitylibs=MWPW-17429-2
