### PR TITLE
[MWPW-174296] Fetch acrobat page variant ID from Target for A/B Testing with edit pdf

### DIFF
--- a/test/utils/experiment-provider.test.js
+++ b/test/utils/experiment-provider.test.js
@@ -1,12 +1,11 @@
+/* eslint-disable no-underscore-dangle */
 import { expect } from '@esm-bundle/chai';
 import getExperimentData from '../../unitylibs/utils/experiment-provider.js';
 
 describe('getExperimentData', () => {
   beforeEach(() => {
     // Mock window._satellite
-    window._satellite = {
-      track: () => {},
-    };
+    window._satellite = { track: () => {} };
   });
 
   afterEach(() => {
@@ -32,13 +31,7 @@ describe('getExperimentData', () => {
 
     window._satellite.track = (event, options) => {
       const mockResult = {
-        decisions: [{
-          items: [{
-            data: {
-              content: mockTargetData,
-            },
-          }],
-        }],
+        decisions: [{ items: [{ data: { content: mockTargetData } }] }],
         propositions: ['test-proposition'],
       };
       setTimeout(() => {
@@ -116,4 +109,4 @@ describe('getExperimentData', () => {
     const result = await getExperimentData();
     expect(result).to.deep.equal({ variationId: 'variant1' });
   });
-}); 
+});

--- a/test/utils/experiment-provider.test.js
+++ b/test/utils/experiment-provider.test.js
@@ -1,0 +1,119 @@
+import { expect } from '@esm-bundle/chai';
+import getExperimentData from '../../unitylibs/utils/experiment-provider.js';
+
+describe('getExperimentData', () => {
+  beforeEach(() => {
+    // Mock window._satellite
+    window._satellite = {
+      track: () => {},
+    };
+  });
+
+  afterEach(() => {
+    delete window._satellite;
+  });
+
+  it('should return default data when target fetch fails', async () => {
+    window._satellite.track = (event, options) => {
+      setTimeout(() => {
+        if (typeof options.done === 'function') options.done(null, new Error('Test error'));
+      }, 0);
+    };
+
+    const result = await getExperimentData();
+    expect(result).to.deep.equal({ variationId: 'variant1' });
+  });
+
+  it('should fetch target data when target returns valid data', async () => {
+    const mockTargetData = {
+      experience: 'test-experience',
+      verb: 'add-comment',
+    };
+
+    window._satellite.track = (event, options) => {
+      const mockResult = {
+        decisions: [{
+          items: [{
+            data: {
+              content: mockTargetData,
+            },
+          }],
+        }],
+        propositions: ['test-proposition'],
+      };
+      setTimeout(() => {
+        if (typeof options.done === 'function') options.done(mockResult, null);
+      }, 0);
+    };
+
+    const result = await getExperimentData();
+    expect(result).to.deep.equal(mockTargetData);
+  });
+
+  it('should return default data when target returns empty decisions', async () => {
+    window._satellite.track = (event, options) => {
+      const mockResult = { decisions: [] };
+      setTimeout(() => {
+        if (typeof options.done === 'function') options.done(mockResult, null);
+      }, 0);
+    };
+
+    const result = await getExperimentData();
+    expect(result).to.deep.equal({ variationId: 'variant1' });
+  });
+
+  it('should return default data when target returns empty items', async () => {
+    window._satellite.track = (event, options) => {
+      const mockResult = { decisions: [{ items: [] }] };
+      setTimeout(() => {
+        if (typeof options.done === 'function') options.done(mockResult, null);
+      }, 0);
+    };
+
+    const result = await getExperimentData();
+    expect(result).to.deep.equal({ variationId: 'variant1' });
+  });
+
+  it('should return default data when target returns invalid structure', async () => {
+    window._satellite.track = (event, options) => {
+      const mockResult = { invalid: 'structure' };
+      setTimeout(() => {
+        if (typeof options.done === 'function') options.done(mockResult, null);
+      }, 0);
+    };
+
+    const result = await getExperimentData();
+    expect(result).to.deep.equal({ variationId: 'variant1' });
+  });
+
+  it('should handle satellite track exceptions', async () => {
+    window._satellite.track = () => {
+      throw new Error('Satellite error');
+    };
+
+    const result = await getExperimentData();
+    expect(result).to.deep.equal({ variationId: 'variant1' });
+  });
+
+  it('should handle null target result', async () => {
+    window._satellite.track = (event, options) => {
+      setTimeout(() => {
+        if (typeof options.done === 'function') options.done(null, null);
+      }, 0);
+    };
+
+    const result = await getExperimentData();
+    expect(result).to.deep.equal({ variationId: 'variant1' });
+  });
+
+  it('should handle undefined target result', async () => {
+    window._satellite.track = (event, options) => {
+      setTimeout(() => {
+        if (typeof options.done === 'function') options.done(undefined, null);
+      }, 0);
+    };
+
+    const result = await getExperimentData();
+    expect(result).to.deep.equal({ variationId: 'variant1' });
+  });
+}); 

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -581,6 +581,9 @@ export default class ActionBinder {
       if (this.multiFileValidationFailure) cOpts.payload.feedback = 'uploaderror';
       if (this.showInfoToast) cOpts.payload.feedback = 'nonpdf';
     }
+    if (this.workflowCfg.targetCfg.experimentationOn.includes(this.workflowCfg.enabledFeatures[0])) {
+      cOpts.payload.variationId = this.experimentData.variationId;
+    }
     await this.getRedirectUrl(cOpts);
     if (!this.redirectUrl) return false;
     const [baseUrl, queryString] = this.redirectUrl.split('?');

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -360,42 +360,10 @@ export default class ActionBinder {
     };
   }
 
-  handlePropositions(TargetPropositionResult) {
-    this.targetData = TargetPropositionResult.decisions[0].items[0].data.content;
-  }
-
-  async fetchTargetResponse() {
-    const decisionScopes = ['ACOM_UNITY_ACROBAT_EDITPDF_POC'];
-    const decisionScopeParams = {
-      countryCode: 'US',
-      firstTimeUser: false,
-      isTrialUser: false,
-      language: 'en-US',
-      subscriptionLevel: '',
-      subscriptionName: '',
-      userRole: '',
-    };
-    try {
-      // eslint-disable-next-line no-underscore-dangle
-      window._satellite.track('propositionFetch', {
-        decisionScopes,
-        data: { __adobe: { target: decisionScopeParams } },
-        done: (TargetPropositionResult, error) => {
-          if (error) {
-            return;
-          }
-          this.handlePropositions(TargetPropositionResult);
-          // eslint-disable-next-line no-underscore-dangle
-          window._satellite.track('propositionDisplay', TargetPropositionResult.propositions);
-        },
-      });
-    // eslint-disable-next-line no-empty
-    } catch (error) { }
-  }
-
   async handlePreloads() {
-    if (this.workflowCfg.targetCfg.experimentationOn.includes(this.workflowCfg.enabledFeatures[0])) {
-      await this.fetchTargetResponse();
+    if (this.workflowCfg.targetCfg?.experimentationOn?.includes(this.workflowCfg.enabledFeatures[0])) {
+      const getExperimentData = (await import('../../../utils/experiment-provider.js')).default;
+      this.experimentData = await getExperimentData();
     }
     const parr = [];
     if (this.workflowCfg.targetCfg.showSplashScreen) {

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -320,8 +320,8 @@ export const unityConfig = (() => {
       ...commoncfg,
     },
     stage: {
-      apiEndPoint: 'https://unity-stage.adobe.io/api/v1',
-      connectorApiEndPoint: 'https://unity-stage.adobe.io/api/v1/asset/connector',
+      apiEndPoint: 'https://unity-dev.adobe.io/api/v1',
+      connectorApiEndPoint: 'https://unity-dev.adobe.io/api/v1/asset/connector',
       env: 'stage',
       ...commoncfg,
     },

--- a/unitylibs/utils/experiment-provider.js
+++ b/unitylibs/utils/experiment-provider.js
@@ -1,0 +1,26 @@
+export default async function getExperimentData() {
+  const decisionScopes = ['ACOM_UNITY_ACROBAT_EDITPDF_POC'];
+
+  return new Promise((resolve) => {
+    // eslint-disable-next-line no-underscore-dangle
+    window._satellite.track('propositionFetch', {
+      decisionScopes,
+      data: { },
+      done: (TargetPropositionResult, error) => {
+        if (error) {
+          resolve({ variationId: 'variant1' });
+          return;
+        }
+
+        const targetData = TargetPropositionResult?.decisions?.[0]?.items?.[0]?.data?.content;
+        if (targetData) {
+          // eslint-disable-next-line no-underscore-dangle
+          window._satellite.track('propositionDisplay', TargetPropositionResult.propositions);
+          resolve(targetData);
+        } else {
+          resolve({ variationId: 'variant1' });
+        }
+      },
+    });
+  });
+}

--- a/unitylibs/utils/experiment-provider.js
+++ b/unitylibs/utils/experiment-provider.js
@@ -2,25 +2,29 @@ export default async function getExperimentData() {
   const decisionScopes = ['ACOM_UNITY_ACROBAT_EDITPDF_POC'];
 
   return new Promise((resolve) => {
-    // eslint-disable-next-line no-underscore-dangle
-    window._satellite.track('propositionFetch', {
-      decisionScopes,
-      data: { },
-      done: (TargetPropositionResult, error) => {
-        if (error) {
-          resolve({ variationId: 'variant1' });
-          return;
-        }
+    try {
+      // eslint-disable-next-line no-underscore-dangle
+      window._satellite.track('propositionFetch', {
+        decisionScopes,
+        data: {},
+        done: (TargetPropositionResult, error) => {
+          if (error) {
+            resolve({ variationId: 'variant1' });
+            return;
+          }
 
-        const targetData = TargetPropositionResult?.decisions?.[0]?.items?.[0]?.data?.content;
-        if (targetData) {
-          // eslint-disable-next-line no-underscore-dangle
-          window._satellite.track('propositionDisplay', TargetPropositionResult.propositions);
-          resolve(targetData);
-        } else {
-          resolve({ variationId: 'variant1' });
-        }
-      },
-    });
+          const targetData = TargetPropositionResult?.decisions?.[0]?.items?.[0]?.data?.content;
+          if (targetData) {
+            // eslint-disable-next-line no-underscore-dangle
+            window._satellite.track('propositionDisplay', TargetPropositionResult.propositions);
+            resolve(targetData);
+          } else {
+            resolve({ variationId: 'variant1' });
+          }
+        },
+      });
+    } catch (e) {
+      resolve({ variationId: 'variant1' });
+    }
   });
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

- Fetch target campaign for mboxid 'ACOM_UNITY_ACROBAT_EDITPDF_POC' for add-comment verb
- Using alloy sdk(_satellite.track) for fetch call 
- Added Unit Test
- Temporarily using dev endpoint of unity BE. To be reverted
- Target code is present in a separate file `experiment-provider.js` for optimisation

Resolves: [MWPW-174296](https://jira.corp.adobe.com/browse/MWPW-174296)

**Test URLs:**
- Before: https://stage--dc--adobecom.aem.page/acrobat/online/compress-pdf
- After: https://stage--dc--adobecom.aem.page/acrobat/online/compress-pdf?unitylibs=MWPW-17429
