### PR TITLE
Fix to flatten enumerable error object

### DIFF
--- a/unitylibs/utils/ObjectUtils.js
+++ b/unitylibs/utils/ObjectUtils.js
@@ -30,7 +30,11 @@ export function flattenObject(obj, options = {}) {
         });
       }
     } else {
-      Object.keys(obj).forEach((key) => {
+      const keys = obj instanceof Error 
+        ? Object.getOwnPropertyNames(obj)
+        : Object.keys(obj);
+        
+      keys.forEach((key) => {
         const value = obj[key];
         const newKey = prefix ? `${prefix}${separator}${key}` : key;
         if (excludeTypes.includes(typeof value)) {


### PR DESCRIPTION
This is in reference to th ePR https://github.com/adobecom/unity/pull/497
Identified a case where flatten object wasn't working which is when the object is enumerable. Added a fix for that

**Test URLs:**
Before: https://stage--dc--adobecom.aem.page/acrobat/online/compress-pdf?unitylibs=stage
After: https://stage--dc--adobecom.hlx.live/acrobat/online/rotate-pdf?unitylibs=imsFix
