### PR TITLE
MWPW-176626 : Error handing for missing verb configuration on unity end

### DIFF
--- a/test/core/workflow/workflow-acrobat/action-binder.test.js
+++ b/test/core/workflow/workflow-acrobat/action-binder.test.js
@@ -1503,13 +1503,12 @@ describe('ActionBinder', () => {
           // Mock the processSingleFile method to avoid other execution paths
           actionBinder.processSingleFile = sinon.stub().resolves();
           actionBinder.processHybrid = sinon.stub().resolves();
-
-          // Set valid enabled feature that exists in LIMITS_MAP
-          actionBinder.workflowCfg.enabledFeatures = ['fillsign'];
-
-          await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
-
-          // Should NOT call dispatchErrorToast for missing verb config
+          actionBinder.workflowCfg.enabledFeatures = ['compress-pdf'];
+          const validFiles = [
+            { name: 'test.pdf', type: 'application/pdf', size: 1048576 },
+          ];
+          const totalFileSize = validFiles.reduce((sum, file) => sum + file.size, 0);
+          await actionBinder.acrobatActionMaps('upload', validFiles, totalFileSize, 'test-event');
           expect(actionBinder.dispatchErrorToast.neverCalledWith(
             'error_generic',
             500,

--- a/test/core/workflow/workflow-acrobat/action-binder.test.js
+++ b/test/core/workflow/workflow-acrobat/action-binder.test.js
@@ -1423,92 +1423,92 @@ describe('ActionBinder', () => {
       describe('enabledFeatures validation', () => {
         it('should dispatch error when enabledFeatures is null', async () => {
           actionBinder.workflowCfg.enabledFeatures = null;
-          
+
           await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
-          
+
           expect(actionBinder.dispatchErrorToast.calledWith(
             'error_generic',
             500,
             'Invalid or missing verb configuration on Unity',
             false,
             true,
-            { code: 'pre_upload_error_missing_verb_config' }
+            { code: 'pre_upload_error_missing_verb_config' },
           )).to.be.true;
         });
 
         it('should dispatch error when enabledFeatures is undefined', async () => {
           actionBinder.workflowCfg.enabledFeatures = undefined;
-          
+
           await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
-          
+
           expect(actionBinder.dispatchErrorToast.calledWith(
             'error_generic',
             500,
             'Invalid or missing verb configuration on Unity',
             false,
             true,
-            { code: 'pre_upload_error_missing_verb_config' }
+            { code: 'pre_upload_error_missing_verb_config' },
           )).to.be.true;
         });
 
         it('should dispatch error when enabledFeatures is empty array', async () => {
           actionBinder.workflowCfg.enabledFeatures = [];
-          
+
           await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
-          
+
           expect(actionBinder.dispatchErrorToast.calledWith(
             'error_generic',
             500,
             'Invalid or missing verb configuration on Unity',
             false,
             true,
-            { code: 'pre_upload_error_missing_verb_config' }
+            { code: 'pre_upload_error_missing_verb_config' },
           )).to.be.true;
         });
 
         it('should dispatch error when enabledFeatures[0] is falsy', async () => {
           actionBinder.workflowCfg.enabledFeatures = [null];
-          
+
           await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
-          
+
           expect(actionBinder.dispatchErrorToast.calledWith(
             'error_generic',
             500,
             'Invalid or missing verb configuration on Unity',
             false,
             true,
-            { code: 'pre_upload_error_missing_verb_config' }
+            { code: 'pre_upload_error_missing_verb_config' },
           )).to.be.true;
         });
 
         it('should dispatch error when enabledFeatures[0] is not in LIMITS_MAP', async () => {
           actionBinder.workflowCfg.enabledFeatures = ['invalid-feature'];
-          
+
           await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
-          
+
           expect(actionBinder.dispatchErrorToast.calledWith(
             'error_generic',
             500,
             'Invalid or missing verb configuration on Unity',
             false,
             true,
-            { code: 'pre_upload_error_missing_verb_config' }
+            { code: 'pre_upload_error_missing_verb_config' },
           )).to.be.true;
         });
 
         it('should not dispatch error when enabledFeatures[0] is valid', async () => {
           // Reset the spy to ensure clean state
           actionBinder.dispatchErrorToast.resetHistory();
-          
+
           // Mock the processSingleFile method to avoid other execution paths
           actionBinder.processSingleFile = sinon.stub().resolves();
           actionBinder.processHybrid = sinon.stub().resolves();
-          
+
           // Set valid enabled feature that exists in LIMITS_MAP
           actionBinder.workflowCfg.enabledFeatures = ['fillsign'];
-          
+
           await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
-          
+
           // Should NOT call dispatchErrorToast for missing verb config
           expect(actionBinder.dispatchErrorToast.neverCalledWith(
             'error_generic',
@@ -1516,7 +1516,7 @@ describe('ActionBinder', () => {
             'Invalid or missing verb configuration on Unity',
             false,
             true,
-            { code: 'pre_upload_error_missing_verb_config' }
+            { code: 'pre_upload_error_missing_verb_config' },
           )).to.be.true;
         });
       });

--- a/test/core/workflow/workflow-acrobat/action-binder.test.js
+++ b/test/core/workflow/workflow-acrobat/action-binder.test.js
@@ -1402,6 +1402,7 @@ describe('ActionBinder', () => {
         };
         actionBinder.signedOut = false;
         actionBinder.tokenError = null;
+        actionBinder.dispatchErrorToast = sinon.stub().resolves();
       });
 
       it('should handle interrupt case', async () => {
@@ -1417,6 +1418,107 @@ describe('ActionBinder', () => {
         await actionBinder.acrobatActionMaps('interrupt', files, 123, 'test-event');
         expect(spy.called).to.be.true;
         spy.restore();
+      });
+
+      describe('enabledFeatures validation', () => {
+        it('should dispatch error when enabledFeatures is null', async () => {
+          actionBinder.workflowCfg.enabledFeatures = null;
+          
+          await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
+          
+          expect(actionBinder.dispatchErrorToast.calledWith(
+            'error_generic',
+            500,
+            'Invalid or missing verb configuration on Unity',
+            false,
+            true,
+            { code: 'pre_upload_error_missing_verb_config' }
+          )).to.be.true;
+        });
+
+        it('should dispatch error when enabledFeatures is undefined', async () => {
+          actionBinder.workflowCfg.enabledFeatures = undefined;
+          
+          await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
+          
+          expect(actionBinder.dispatchErrorToast.calledWith(
+            'error_generic',
+            500,
+            'Invalid or missing verb configuration on Unity',
+            false,
+            true,
+            { code: 'pre_upload_error_missing_verb_config' }
+          )).to.be.true;
+        });
+
+        it('should dispatch error when enabledFeatures is empty array', async () => {
+          actionBinder.workflowCfg.enabledFeatures = [];
+          
+          await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
+          
+          expect(actionBinder.dispatchErrorToast.calledWith(
+            'error_generic',
+            500,
+            'Invalid or missing verb configuration on Unity',
+            false,
+            true,
+            { code: 'pre_upload_error_missing_verb_config' }
+          )).to.be.true;
+        });
+
+        it('should dispatch error when enabledFeatures[0] is falsy', async () => {
+          actionBinder.workflowCfg.enabledFeatures = [null];
+          
+          await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
+          
+          expect(actionBinder.dispatchErrorToast.calledWith(
+            'error_generic',
+            500,
+            'Invalid or missing verb configuration on Unity',
+            false,
+            true,
+            { code: 'pre_upload_error_missing_verb_config' }
+          )).to.be.true;
+        });
+
+        it('should dispatch error when enabledFeatures[0] is not in LIMITS_MAP', async () => {
+          actionBinder.workflowCfg.enabledFeatures = ['invalid-feature'];
+          
+          await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
+          
+          expect(actionBinder.dispatchErrorToast.calledWith(
+            'error_generic',
+            500,
+            'Invalid or missing verb configuration on Unity',
+            false,
+            true,
+            { code: 'pre_upload_error_missing_verb_config' }
+          )).to.be.true;
+        });
+
+        it('should not dispatch error when enabledFeatures[0] is valid', async () => {
+          // Reset the spy to ensure clean state
+          actionBinder.dispatchErrorToast.resetHistory();
+          
+          // Mock the processSingleFile method to avoid other execution paths
+          actionBinder.processSingleFile = sinon.stub().resolves();
+          actionBinder.processHybrid = sinon.stub().resolves();
+          
+          // Set valid enabled feature that exists in LIMITS_MAP
+          actionBinder.workflowCfg.enabledFeatures = ['fillsign'];
+          
+          await actionBinder.acrobatActionMaps('upload', [], 0, 'test-event');
+          
+          // Should NOT call dispatchErrorToast for missing verb config
+          expect(actionBinder.dispatchErrorToast.neverCalledWith(
+            'error_generic',
+            500,
+            'Invalid or missing verb configuration on Unity',
+            false,
+            true,
+            { code: 'pre_upload_error_missing_verb_config' }
+          )).to.be.true;
+        });
       });
     });
 

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -210,6 +210,7 @@ export default class ActionBinder {
     pre_upload_error_fetch_redirect_url: -53,
     pre_upload_error_fetching_access_token: -54,
     pre_upload_error_create_asset: -55,
+    pre_upload_error_missing_verb_config: -56,
     validation_error_validate_files: -100,
     validation_error_unsupported_type: -101,
     validation_error_empty_file: -102,
@@ -733,6 +734,12 @@ export default class ActionBinder {
     window.addEventListener('DCUnity:RedirectReady', async () => {
       await this.continueInApp();
     });
+    if (!this.workflowCfg.enabledFeatures || !this.workflowCfg.enabledFeatures[0] || !ActionBinder.LIMITS_MAP[this.workflowCfg.enabledFeatures[0]]) {
+      await this.dispatchErrorToast('error_generic', 500, 'Invalid or missing verb configuration on Unity', false, true, {
+        code: 'pre_upload_error_missing_verb_config'
+      });
+      return;
+    }
     const uploadType = ActionBinder.LIMITS_MAP[this.workflowCfg.enabledFeatures[0]][0];
     switch (value) {
       case 'upload':

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -360,43 +360,7 @@ export default class ActionBinder {
     };
   }
 
-  handlePropositions(TargetPropositionResult) {
-    this.targetData = TargetPropositionResult.decisions[0].items[0].data.content;
-  }
-
-  async fetchTargetResponse() {
-    const decisionScopes = ['ACOM_UNITY_ACROBAT_EDITPDF_POC'];
-    const decisionScopeParams = {
-      countryCode: 'US',
-      firstTimeUser: false,
-      isTrialUser: false,
-      language: 'en-US',
-      subscriptionLevel: '',
-      subscriptionName: '',
-      userRole: '',
-    };
-    try {
-      // eslint-disable-next-line no-underscore-dangle
-      window._satellite.track('propositionFetch', {
-        decisionScopes,
-        data: { __adobe: { target: decisionScopeParams } },
-        done: (TargetPropositionResult, error) => {
-          if (error) {
-            return;
-          }
-          this.handlePropositions(TargetPropositionResult);
-          // eslint-disable-next-line no-underscore-dangle
-          window._satellite.track('propositionDisplay', TargetPropositionResult.propositions);
-        },
-      });
-    // eslint-disable-next-line no-empty
-    } catch (error) { }
-  }
-
   async handlePreloads() {
-    if (this.workflowCfg.targetCfg.experimentationOn.includes(this.workflowCfg.enabledFeatures[0])) {
-      await this.fetchTargetResponse();
-    }
     const parr = [];
     if (this.workflowCfg.targetCfg.showSplashScreen) {
       parr.push(

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -366,11 +366,20 @@ export default class ActionBinder {
 
   async fetchTargetResponse() {
     const decisionScopes = ['ACOM_UNITY_ACROBAT_EDITPDF_POC'];
+    const decisionScopeParams = {
+      countryCode: 'US',
+      firstTimeUser: false,
+      isTrialUser: false,
+      language: 'en-US',
+      subscriptionLevel: '',
+      subscriptionName: '',
+      userRole: '',
+    };
     try {
       // eslint-disable-next-line no-underscore-dangle
       window._satellite.track('propositionFetch', {
         decisionScopes,
-        data: { },
+        data: { __adobe: { target: decisionScopeParams } },
         done: (TargetPropositionResult, error) => {
           if (error) {
             return;

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -735,9 +735,7 @@ export default class ActionBinder {
       await this.continueInApp();
     });
     if (!this.workflowCfg.enabledFeatures || !this.workflowCfg.enabledFeatures[0] || !ActionBinder.LIMITS_MAP[this.workflowCfg.enabledFeatures[0]]) {
-      await this.dispatchErrorToast('error_generic', 500, 'Invalid or missing verb configuration on Unity', false, true, {
-        code: 'pre_upload_error_missing_verb_config'
-      });
+      await this.dispatchErrorToast('error_generic', 500, 'Invalid or missing verb configuration on Unity', false, true, { code: 'pre_upload_error_missing_verb_config' });
       return;
     }
     const uploadType = ActionBinder.LIMITS_MAP[this.workflowCfg.enabledFeatures[0]][0];

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -360,7 +360,34 @@ export default class ActionBinder {
     };
   }
 
+  handlePropositions(TargetPropositionResult) {
+    this.targetData = TargetPropositionResult.decisions[0].items[0].data.content;
+  }
+
+  async fetchTargetResponse() {
+    const decisionScopes = ['ACOM_UNITY_ACROBAT_EDITPDF_POC'];
+    try {
+      // eslint-disable-next-line no-underscore-dangle
+      window._satellite.track('propositionFetch', {
+        decisionScopes,
+        data: { },
+        done: (TargetPropositionResult, error) => {
+          if (error) {
+            return;
+          }
+          this.handlePropositions(TargetPropositionResult);
+          // eslint-disable-next-line no-underscore-dangle
+          window._satellite.track('propositionDisplay', TargetPropositionResult.propositions);
+        },
+      });
+    // eslint-disable-next-line no-empty
+    } catch (error) { }
+  }
+
   async handlePreloads() {
+    if (this.workflowCfg.targetCfg.experimentationOn.includes(this.workflowCfg.enabledFeatures[0])) {
+      await this.fetchTargetResponse();
+    }
     const parr = [];
     if (this.workflowCfg.targetCfg.showSplashScreen) {
       parr.push(

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -734,7 +734,7 @@ export default class ActionBinder {
     window.addEventListener('DCUnity:RedirectReady', async () => {
       await this.continueInApp();
     });
-    if (!this.workflowCfg.enabledFeatures || !this.workflowCfg.enabledFeatures[0] || !ActionBinder.LIMITS_MAP[this.workflowCfg.enabledFeatures[0]]) {
+    if (!this.workflowCfg.enabledFeatures?.length || !ActionBinder.LIMITS_MAP[this.workflowCfg.enabledFeatures[0]]) {
       await this.dispatchErrorToast('error_generic', 500, 'Invalid or missing verb configuration on Unity', false, true, { code: 'pre_upload_error_missing_verb_config' });
       return;
     }

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -19,7 +19,6 @@
     "nonpdfMfuFeedbackScreenTypeNonpdf": ["combine-pdf"],
     "nonpdfSfuProductScreen": ["word-to-pdf", "jpg-to-pdf", "ppt-to-pdf", "excel-to-pdf", "png-to-pdf", "createpdf", "chat-pdf", "chat-pdf-student"],
     "mfuUploadAllowed": ["combine-pdf", "rotate-pages", "chat-pdf", "chat-pdf-student"],
-    "mfuUploadOnlyPdfAllowed": ["combine-pdf"],
-    "experimentationOn": ["add-comment"]
+    "mfuUploadOnlyPdfAllowed": ["combine-pdf"]
   }
 }

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -19,6 +19,7 @@
     "nonpdfMfuFeedbackScreenTypeNonpdf": ["combine-pdf"],
     "nonpdfSfuProductScreen": ["word-to-pdf", "jpg-to-pdf", "ppt-to-pdf", "excel-to-pdf", "png-to-pdf", "createpdf", "chat-pdf", "chat-pdf-student"],
     "mfuUploadAllowed": ["combine-pdf", "rotate-pages", "chat-pdf", "chat-pdf-student"],
-    "mfuUploadOnlyPdfAllowed": ["combine-pdf"]
+    "mfuUploadOnlyPdfAllowed": ["combine-pdf"],
+    "experimentationOn": ["number-pages"]
   }
 }

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -20,6 +20,6 @@
     "nonpdfSfuProductScreen": ["word-to-pdf", "jpg-to-pdf", "ppt-to-pdf", "excel-to-pdf", "png-to-pdf", "createpdf", "chat-pdf", "chat-pdf-student"],
     "mfuUploadAllowed": ["combine-pdf", "rotate-pages", "chat-pdf", "chat-pdf-student"],
     "mfuUploadOnlyPdfAllowed": ["combine-pdf"],
-    "experimentationOn": ["number-pages"]
+    "experimentationOn": ["add-comment"]
   }
 }


### PR DESCRIPTION
As a safety check If enabledFeatures is empty let's go ahead and throw a generic error in the UI and log a message in the analytics

Resolves: [MWPW-176626](https://jira.corp.adobe.com/browse/MWPW-176626)

**Test URLs:**
Before: https://stage--dc--adobecom.aem.live/acrobat/online/test/ai-summary-generator?unitylibs=stage
After: https://stage--dc--adobecom.aem.live/acrobat/online/test/ai-summary-generator?unitylibs=missingVerb
