### PR TITLE
MWPW-177043 - Initial selected verb text for ROW not translating

### DIFF
--- a/unitylibs/core/workflow/workflow-firefly/widget.js
+++ b/unitylibs/core/workflow/workflow-firefly/widget.js
@@ -135,7 +135,7 @@ export default class UnityWidget {
       'aria-controls': 'prompt-menu',
       'aria-label': `${selectedVerbType} prompt: ${inputPlaceHolder}`,
       'data-selected-verb': selectedVerbType,
-    }, `<img src="${href}" alt="" />${selectedVerbType}`);
+    }, `<img src="${href}" alt="" />${selectedVerb?.textContent.trim()}`);
     this.selectedVerbType = selectedVerbType;
     this.widgetWrap.setAttribute('data-selected-verb', this.selectedVerbType);
     this.selectedVerbText = selectedVerb?.textContent.trim();


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fixes issue for page initial load - selected verb text not showing translated text for ROW pages.

Resolves: [MWPW-177043](https://jira.corp.adobe.com/browse/MWPW-177043)

**Test ROW URLs:**
- Before: https://main--cc--adobecom.aem.page/jp/products/firefly/features/text-to-image?martech=off
- After: https://main--cc--adobecom.aem.page/jp/products/firefly/features/text-to-image?unitylibs=ff-selected-verb-row&martech=off
- Before: https://main--cc--adobecom.aem.page/il_he/products/firefly/features/text-to-image?martech=off
- After: https://main--cc--adobecom.aem.page/il_he/products/firefly/features/text-to-image?unitylibs=ff-selected-verb-row&martech=off

**Test English URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/rclayton/firefly/text-to-image?martech=off
- After: https://main--cc--adobecom.aem.page/drafts/rclayton/firefly/text-to-image?unitylibs=ff-selected-verb-row&martech=off