### PR TITLE
[MWPW-177381] : Switching summary generator from MFU to SFU

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -200,7 +200,7 @@ export default class ActionBinder {
     'ocr-pdf': ['hybrid', 'allowed-filetypes-pdf-word-excel-ppt-img-txt', 'page-limit-100', 'max-filesize-100-mb'],
     'chat-pdf': ['hybrid', 'allowed-filetypes-pdf-word-ppt-txt', 'page-limit-600', 'max-numfiles-10', 'max-filesize-100-mb'],
     'chat-pdf-student': ['hybrid', 'allowed-filetypes-pdf-word-ppt-txt', 'page-limit-600', 'max-numfiles-10', 'max-filesize-100-mb'],
-    'summarize-pdf': ['hybrid', 'allowed-filetypes-pdf-word-ppt-txt', 'page-limit-600', 'max-numfiles-10', 'max-filesize-100-mb'],
+    'summarize-pdf': ['single', 'allowed-filetypes-pdf-word-ppt-txt', 'page-limit-600', 'max-filesize-100-mb'],
   };
 
   static ERROR_MAP = {


### PR DESCRIPTION
As per the updated requirements from the product, this PR consists config change to restrict summary-generator to SFU

Resolves: [MWPW-177381](https://jira.corp.adobe.com/browse/MWPW-177381)

**Test URLs:**
Before: https://stage--dc--adobecom.aem.live/acrobat/online/merge-pdf?unitylibs=stage
After: https://stage--dc--adobecom.aem.live/acrobat/online/merge-pdf?unitylibs=sumGenSFU
