### PR TITLE
MWPW-179476 Add PDF to PNG verb to Acrobat Workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/*
 .idea
 test-html-results/
 test-results/
+.cursor/

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -188,6 +188,7 @@ export default class ActionBinder {
     'pdf-to-excel': ['hybrid', 'allowed-filetypes-pdf-only', 'max-filesize-100-mb'],
     'pdf-to-ppt': ['hybrid', 'allowed-filetypes-pdf-only', 'max-filesize-250-mb'],
     'pdf-to-image': ['hybrid', 'allowed-filetypes-pdf-only', 'max-filesize-100-mb'],
+    'pdf-to-png': ['hybrid', 'allowed-filetypes-pdf-only', 'max-filesize-100-mb', 'page-limit-600'],
     createpdf: ['hybrid', 'allowed-filetypes-all', 'max-filesize-100-mb'],
     'word-to-pdf': ['hybrid', 'allowed-filetypes-all', 'max-filesize-100-mb'],
     'excel-to-pdf': ['hybrid', 'allowed-filetypes-all', 'max-filesize-100-mb'],
@@ -458,6 +459,7 @@ export default class ActionBinder {
       'pdf-to-excel': ['application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
       'pdf-to-ppt': ['application/vnd.ms-powerpoint', 'application/vnd.openxmlformats-officedocument.presentationml.presentation'],
       'pdf-to-image': ['image/jpeg', 'image/png'],
+      'pdf-to-png': ['image/jpeg', 'image/png', 'image/tiff'],
     };
     return verbToFileTypeMap[verb]?.includes(fileType) || false;
   }

--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -293,6 +293,7 @@ class WfInitiator {
           'pdf-to-excel',
           'pdf-to-ppt',
           'pdf-to-image',
+          'pdf-to-png',
           'createpdf',
           'word-to-pdf',
           'excel-to-pdf',


### PR DESCRIPTION
Adds the new pdf-to-png verb to Acrobat workflow.

Changes:
- Register verb in workflow supported features.
- Configure limits: PDF-only, 100 MB, 600 pages.
- Treat jpg/png/tiff as same-format to dispatch error.

Validation:
- All tests pass locally (437 passed, 0 failed).

Risks:
- None expected; follows existing patterns for pdf-to-image.
