### PR TITLE
[Do not merge][MWPW-179252] Adding support for fixing Multi Region Unity Calls - option1

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -346,12 +346,74 @@ export default class ActionBinder {
   }
 
   getAcrobatApiConfig() {
+    console.log('getAcrobatApiConfig called');
     unityConfig.acrobatEndpoint = {
       createAsset: `${unityConfig.apiEndPoint}/asset`,
       finalizeAsset: `${unityConfig.apiEndPoint}/asset/finalize`,
       getMetadata: `${unityConfig.apiEndPoint}/asset/metadata`,
+      connector: `${unityConfig.apiEndPoint}/asset/connector`,
     };
     return unityConfig;
+  }
+
+  async ensureOptimalEndpoint() {
+    // Ensure pageConfig has resolved before making API calls
+    if (this.pageConfigPromise) {
+      console.log('Waiting for pageConfig to complete before making any API calls...');
+      const startTime = performance.now();
+      await this.pageConfigPromise;
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+      console.log(`PageConfig wait took ${duration.toFixed(2)}ms - API endpoints ready`);
+      // Clear promise after use
+      this.pageConfigPromise = null;
+    }
+  }
+
+  async checkandUpdatePageConfigEndpoint() {
+    console.log('Starting pageConfig fetch during upload initiation...');
+    const TIMEOUT_MS = 2000; // 2000ms timeout
+    try {
+      // Setup timeout handling
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => {
+        controller.abort();
+        console.warn('PageConfig request timed out, using default endpoint');
+      }, TIMEOUT_MS);
+
+      const getOpts = {
+        method: 'GET',
+        headers: await getHeaders(unityConfig.apiKey, {}),
+        signal: controller.signal,
+      };
+      const url = `${unityConfig.apiEndPoint}/pageConfig`;
+      
+      const pageConfigResponse = await fetch(url, getOpts);
+      clearTimeout(timeoutId);
+      
+      if (pageConfigResponse.ok) {
+        const locationHeader = pageConfigResponse.headers.get('location');
+        if (locationHeader) {
+          const newEndpoint = `${locationHeader}/api/v1`;
+          
+          // Update config
+          unityConfig.apiEndPoint = newEndpoint;
+          this.acrobatApiConfig = this.getAcrobatApiConfig();
+          
+          console.log('PageConfig endpoint updated:', newEndpoint);
+        } else {
+          console.log('No location header found, keeping existing API endpoint');
+        }
+      } else {
+        console.warn(`PageConfig GET request returned status: ${pageConfigResponse.status}`);
+      }
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        console.warn('PageConfig request timed out, continuing with default endpoint');
+      } else {
+        console.error('PageConfig GET request failed:', error);
+      }
+    }
   }
 
   getAdditionalHeaders() {
@@ -542,7 +604,7 @@ export default class ActionBinder {
   async getRedirectUrl(cOpts) {
     this.promiseStack.push(
       this.serviceHandler.postCallToService(
-        this.acrobatApiConfig.connectorApiEndPoint,
+        this.acrobatApiConfig.acrobatEndpoint.connector,
         { body: JSON.stringify(cOpts) },
         this.getAdditionalHeaders(),
       ),
@@ -797,6 +859,7 @@ export default class ActionBinder {
   }
 
   async initActionListeners(b = this.block, actMap = this.actionMap) {
+    console.log('initActionListeners called');
     for (const [key, value] of Object.entries(actMap)) {
       const el = b.querySelector(key);
       if (!el) return;
@@ -827,6 +890,9 @@ export default class ActionBinder {
     }
     if (b === this.block) {
       this.loadTransitionScreen();
+    }
+    if (!this.pageConfigPromise) {
+      this.pageConfigPromise = this.checkandUpdatePageConfigEndpoint();
     }
   }
 }

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -413,6 +413,7 @@ export default class UploadHandler {
     let cOpts = {};
     let blobData; let assetData;
     try {
+      await this.actionBinder.ensureOptimalEndpoint();
       [blobData, assetData] = await Promise.all([
         this.getBlobData(file),
         this.createAsset(file),
@@ -570,6 +571,7 @@ export default class UploadHandler {
     const blobDataArray = [];
     const assetDataArray = [];
     const fileTypeArray = [];
+    await this.actionBinder.ensureOptimalEndpoint();
     await this.executeInBatches(files, maxConcurrentFiles, async (file) => {
       try {
         const [blobData, assetData] = await Promise.all([

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -279,13 +279,13 @@ export const unityConfig = (() => {
   };
   const cfg = {
     prod: {
-      apiEndPoint: 'https://unity.adobe.io/api/v1',
+      apiEndPoint: 'https://unity-dev.adobe.io/api/v1',
       connectorApiEndPoint: 'https://unity.adobe.io/api/v1/asset/connector',
       env: 'prod',
       ...commoncfg,
     },
     stage: {
-      apiEndPoint: 'https://unity-stage.adobe.io/api/v1',
+      apiEndPoint: 'https://unity-dev.adobe.io/api/v1',
       connectorApiEndPoint: 'https://unity-stage.adobe.io/api/v1/asset/connector',
       env: 'stage',
       ...commoncfg,


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

1. Added support for fetching the base url via pageConfig call
2. Making this non-blocking call just at the end of page loading, before user workflow is initiated

Resolves: [MWPW-179252](https://jira.corp.adobe.com/browse/MWPW-179252)

**Test URLs:**
- Before: https://stage--dc--adobecom.aem.live/acrobat/online/compress-pdf?unitylibs=stage
- After: https://stage--dc--adobecom.aem.page/acrobat/online/compress-pdf?unitylibs=vipulg-MWPW-179252_option1
