### PR TITLE
[MWPW-181401][NALA] Temporarily disable pdf-editor test on firefox browser

### DIFF
--- a/nala/features/pdf-editor/pdf-editor.test.cjs
+++ b/nala/features/pdf-editor/pdf-editor.test.cjs
@@ -15,7 +15,10 @@ test.describe('Unity PDF Editor test suite', () => {
   });
 
   // Test 0 : PDF Editor or Add-Comment
-  test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
+  test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL, browserName }) => {
+    // Skip test for Firefox browser till further investigation
+    test.skip(browserName === 'firefox', 'Skipping on Firefox till further investigation');
+
     console.info(`[Test Page]: ${baseURL}${features[0].path}${unityLibs}`);
     const { data } = features[0];
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* The pdf-editor automation test is currently unstable on the Firefox browser. To avoid false negatives in the CI pipeline, the test should be temporarily skipped when executed under Firefox
* Add `test.skip(browserName === 'firefox', 'Skipping on Firefox')`; in the pdf-editor test file.
* Ensure the test continues to run on Chromium and WebKit browsers.
* Add a console log message during skip for easier tracking in CI logs.

Resolves: [MWPW-181401](https://jira.corp.adobe.com/browse/MWPW-181401)

**Test URLs:**
- Before: https://main--unity--adobecom.aem.page/?martech=off
- After: https://pdf-editor-skip-unity--adobecom.aem.page/?martech=off
