### PR TITLE
small fix to bifercate firefly analytics for upload and generate workflow

### DIFF
--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -348,7 +348,7 @@ export default class ActionBinder {
 
   logAnalyticsinSplunk(eventName, data) {
     if (this.sendAnalyticsToSplunk) {
-      this.sendAnalyticsToSplunk(eventName, this.workflowCfg.productName, data, `${unityConfig.apiEndPoint}/log`);
+      this.sendAnalyticsToSplunk(eventName, this.workflowCfg.productName, { ...data, action: 'upload' }, `${unityConfig.apiEndPoint}/log`);
     }
   }
 


### PR DESCRIPTION
Currently there is no field to separate firefly upload analytics from firefly generate workflow. So in dashboard, for product firefly - it brings up analytics for both the workflows. 



**Test URLs:**
Before: https://main--cc--adobecom.aem.live/products/firefly/features/ai-photo-editor?unitylibs=stage
After: https://main--cc--adobecom.aem.live/products/firefly/features/ai-photo-editor?unitylibs=ff-analytics-fix
