### PR TITLE
[MWPW-191060] update milolibs and baseUrl for acrobat subdomain

### DIFF
--- a/unitylibs/scripts/errors.js
+++ b/unitylibs/scripts/errors.js
@@ -27,10 +27,8 @@ async function loadErrorMessages(verb) {
   let baseUrl;
   if (origin.includes('.aem.') || origin.includes('.hlx.')) {
     baseUrl = `https://main--unity--adobecom.${origin.includes('.hlx.') ? 'hlx' : 'aem'}.live`;
-  } else if (origin === 'https://stage.acrobat.adobe.com') {
-    baseUrl = 'https://milo.stage.adobe.com';
-  } else if (origin === 'https://acrobat.adobe.com') {
-    baseUrl = 'https://milo.adobe.com';
+  } else if (origin.endsWith('acrobat.adobe.com')) {
+    baseUrl = `${origin}/dc-shared`;
   } else {
     baseUrl = origin;
   }

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -3,8 +3,8 @@ export const [setLibs, getLibs] = (() => {
   return [
     (prodLibs, location) => {
       libs = (() => {
-        const { hostname, search } = location || window.location;
-        if (hostname.endsWith('acrobat.adobe.com')) return '/dc-shared/libs';
+        const { hostname, origin, search } = location || window.location;
+        if (hostname.endsWith('acrobat.adobe.com')) return `${origin}/dc-shared/libs`;
         if (!(hostname.includes('.hlx.') || hostname.includes('.aem.') || hostname.includes('local'))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
         if (branch === 'local') return 'http://localhost:6456/libs';

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -4,8 +4,7 @@ export const [setLibs, getLibs] = (() => {
     (prodLibs, location) => {
       libs = (() => {
         const { hostname, search } = location || window.location;
-        if (hostname === 'acrobat.adobe.com') return 'https://milo.adobe.com/libs';
-        if (hostname === 'stage.acrobat.adobe.com') return 'https://milo.stage.adobe.com/libs';
+        if (hostname.endsWith('acrobat.adobe.com')) return '/dc-shared/libs';
         if (!(hostname.includes('.hlx.') || hostname.includes('.aem.') || hostname.includes('local'))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
         if (branch === 'local') return 'http://localhost:6456/libs';


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Resolves: https://jira.corp.adobe.com/browse/MWPW-191060

**Test URLs:**
- Before: https://stage.acrobat.adobe.com/heic-to-pdf
- After: https://stage.acrobat.adobe.com/heic-to-pdf?unitylibs=acrobat-libs-mapping

Can be tested on stage.acrobat.adobe.com only. You should see that unity is able to load milo libs on its own successfully.
