### PR TITLE
[MWPW-190880] Populate prompt on style selection if input is empty

### DIFF
--- a/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.js
+++ b/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.js
@@ -678,13 +678,15 @@ function attachPromptBarStyleInteractivity(styles, previewRows, inpField, styleI
     clearEmptyPromptRestoreTimer();
     const prevIdx = currentStyleIdx;
     const prevDefault = styles[prevIdx]?.prompt ?? '';
-    const stillSyncedWithPreviousStyle = inpField.value === prevDefault;
+    const { value } = inpField;
+    const stillSyncedWithPreviousStyle = value === prevDefault;
+    const promptWasCleared = value.trim() === '';
     currentStyleIdx = idx;
     styleItems.forEach((item, i) => {
       item.classList.toggle('selected', i === idx);
       item.setAttribute('aria-selected', i === idx ? 'true' : 'false');
     });
-    if (stillSyncedWithPreviousStyle) {
+    if (stillSyncedWithPreviousStyle || promptWasCleared) {
       inpField.value = styles[idx].prompt;
     }
     const col = currentPreviewColumn();


### PR DESCRIPTION
If a user clears the default prompt then selecting a style should repopulate the prompt.

Resolves: [MWPW-190880](https://jira.corp.adobe.com/browse/MWPW-190880)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/vipulg/doodlebug/v152/vg-ai-graphic-design-generator?unitylibs=stage
- After: https://main--cc--adobecom.aem.page/drafts/vipulg/doodlebug/v152/vg-ai-graphic-design-generator?unitylibs=MWPW-190880-1
