### PR TITLE
[MWPW-191235] Dropdown does not close when the focus comes out of it …

### DIFF
--- a/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.js
+++ b/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.js
@@ -285,6 +285,21 @@ export class UnityWidget {
       if (!link) return;
       this.handleVerbLinkClick(link, listContainer, selectedElement, menuIcon, inputPlaceHolder, isModelList)(e);
     });
+    listContainer.addEventListener('keydown', (e) => {
+      if (e.key !== 'Tab') return;
+      const menuContainer = selectedElement.parentElement;
+      if (!menuContainer?.classList.contains('show-menu')) return;
+      const links = listContainer.querySelectorAll('.verb-link');
+      if (!links.length) return;
+      const active = document.activeElement;
+      const idx = [...links].findIndex((a) => a === active || a.contains(active));
+      if (idx < 0) return;
+      const atStart = idx === 0;
+      const atEnd = idx === links.length - 1;
+      if ((e.shiftKey && atStart) || (!e.shiftKey && atEnd)) {
+        this.closeVerbOrModelMenu(selectedElement);
+      }
+    });
   }
 
   modelDropdown() {


### PR DESCRIPTION
Dropdown does not close when the focus comes out of it while tabbing

Resolves: [MWPW-191235](https://jira.corp.adobe.com/browse/MWPW-191235)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/products/firefly/features/ai-graphic-design-generator?unitylibs=stage
- After: https://main--cc--adobecom.aem.page/products/firefly/features/ai-graphic-design-generator?unitylibs=doodlebug-v152-1
