### PR TITLE
[MWPW-190479] Uploaded event going even when user click cancel

### DIFF
--- a/test/core/workflow/workflow-upload/action-binder.test.js
+++ b/test/core/workflow/workflow-upload/action-binder.test.js
@@ -6,7 +6,8 @@ import { setUnityLibs } from '../../../../unitylibs/scripts/utils.js';
 setUnityLibs('/unitylibs');
 
 window.adobeIMS = {
-  getAccessToken: () => ({ token: 'token', expire: { valueOf: () => Date.now() + (5 * 60 * 1000) } }),
+  // Expire well beyond getImsToken's 5-minute refresh window so finalize (scan) does not trigger token refresh.
+  getAccessToken: () => ({ token: 'token', expire: { valueOf: () => Date.now() + (60 * 60 * 1000) } }),
   adobeid: { locale: 'en' },
 };
 
@@ -254,6 +255,14 @@ describe('Unity Upload Block', () => {
           return Promise.resolve({
             status: 200,
             ok: true,
+            headers: new Headers({ 'Content-Length': '0' }),
+          });
+        }
+        if (options && options.method === 'POST') {
+          return Promise.resolve({
+            status: 200,
+            ok: true,
+            headers: new Headers({ 'Content-Length': '0' }),
           });
         }
         return originalFetch(url, options);
@@ -920,7 +929,7 @@ describe('Unity Upload Block', () => {
       unityEl.appendChild(cgenElement);
 
       actionBinder.serviceHandler = {
-        postCallToService: async () => ({ status: 200 }),
+        postCallToService: async () => ({ id: 'test-asset-id', href: 'https://test-url.com' }),
         showErrorToast: () => {},
       };
 
@@ -945,6 +954,14 @@ describe('Unity Upload Block', () => {
           return Promise.resolve({
             status: 200,
             ok: true,
+            headers: new Headers({ 'Content-Length': '0' }),
+          });
+        }
+        if (options && options.method === 'POST') {
+          return Promise.resolve({
+            status: 200,
+            ok: true,
+            headers: new Headers({ 'Content-Length': '0' }),
           });
         }
         return originalFetch(url, options);

--- a/test/core/workflow/workflow-upload/upload-handler.test.js
+++ b/test/core/workflow/workflow-upload/upload-handler.test.js
@@ -164,7 +164,7 @@ describe('UploadHandler', () => {
 
       expect(window.fetch.calledTwice).to.be.true;
       expect(result.failedChunks.size).to.equal(0);
-      expect(mockActionBinder.logAnalyticsinSplunk.calledWith('Chunked Upload Completed|UnityWidget')).to.be.true;
+      expect(mockActionBinder.logAnalyticsinSplunk.calledWith('Chunked Upload Completed|UnityWidget')).to.be.false;
     });
 
     it('should handle empty file', async () => {

--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -86,6 +86,7 @@ export default class ActionBinder {
     this.assetId = null;
     this.filesData = {};
     this.verb = this.getVerbFromDom();
+    this.uploadAbortController = null;
   }
 
   getApiConfig() {
@@ -117,6 +118,7 @@ export default class ActionBinder {
 
   async cancelUploadOperation() {
     try {
+      this.uploadAbortController?.abort();
       sendAnalyticsEvent(new CustomEvent('Cancel|UnityWidget'));
       this.logAnalyticsinSplunk('Cancel|UnityWidget', { assetId: this.assetId });
       const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
@@ -144,11 +146,12 @@ export default class ActionBinder {
     return files;
   }
 
-  async uploadImgToUnity(storageUrl, id, blobData, fileType) {
+  async uploadImgToUnity(storageUrl, id, blobData, fileType, signal) {
     const uploadOptions = {
       method: 'PUT',
       headers: { 'Content-Type': fileType },
       body: blobData,
+      ...(signal && { signal }),
     };
     const response = await fetch(storageUrl, uploadOptions);
     if (response.status !== 200) {
@@ -157,12 +160,16 @@ export default class ActionBinder {
       error.status = response.status;
       throw error;
     }
-    this.logAnalyticsinSplunk('Upload Completed|UnityWidget', { assetId: this.assetId });
   }
 
-  async scanImgForSafety(assetId) {
+  async scanImgForSafety(assetId, signal) {
+    if (signal?.aborted) {
+      const err = new Error('Operation aborted');
+      err.name = 'AbortError';
+      throw err;
+    }
     const assetData = { assetId, targetProduct: this.workflowCfg.productName };
-    const optionsBody = { body: JSON.stringify(assetData) };
+    const optionsBody = { body: JSON.stringify(assetData), ...(signal && { signal }) };
     const res = await this.serviceHandler.postCallToService(
       this.apiConfig.endPoint.acmpCheck,
       optionsBody,
@@ -170,7 +177,12 @@ export default class ActionBinder {
       false,
     );
     if (res.status === 429 || (res.status >= 500 && res.status < 600)) {
-      setTimeout(() => { this.scanImgForSafety(assetId); }, 1000);
+      if (signal?.aborted) {
+        const err = new Error('Operation aborted');
+        err.name = 'AbortError';
+        throw err;
+      }
+      setTimeout(() => { this.scanImgForSafety(assetId, signal); }, 1000);
     }
   }
 
@@ -181,6 +193,8 @@ export default class ActionBinder {
       size: file.size,
       format: file.type,
     };
+    this.uploadAbortController = new AbortController();
+    const { signal } = this.uploadAbortController;
     try {
       const resJson = await this.serviceHandler.postCallToService(
         this.apiConfig.endPoint.assetUpload,
@@ -190,10 +204,10 @@ export default class ActionBinder {
       const { id, href, blocksize, uploadUrls } = resJson;
       this.assetId = id;
       this.logAnalyticsinSplunk('Asset Created|UnityWidget', { assetId: this.assetId });
+      const { default: UploadHandler } = await import(`${getUnityLibs()}/core/workflow/workflow-upload/upload-handler.js`);
+      const uploadHandler = new UploadHandler(this, this.serviceHandler);
       if (blocksize && uploadUrls && Array.isArray(uploadUrls)) {
-        const { default: UploadHandler } = await import(`${getUnityLibs()}/core/workflow/workflow-upload/upload-handler.js`);
-        const uploadHandler = new UploadHandler(this, this.serviceHandler);
-        const { failedChunks, attemptMap } = await uploadHandler.uploadChunksToUnity(uploadUrls, file, blocksize);
+        const { failedChunks, attemptMap } = await uploadHandler.uploadChunksToUnity(uploadUrls, file, blocksize, signal);
         if (failedChunks && failedChunks.size > 0) {
           const error = new Error(`One or more chunks failed to upload for asset: ${id}, ${file.size} bytes, ${file.type}`);
           error.status = 504;
@@ -204,13 +218,29 @@ export default class ActionBinder {
           });
           throw error;
         }
-        await uploadHandler.scanImgForSafetyWithRetry(this.assetId);
+        await this.scanImgForSafety(this.assetId, signal);
+        const { createChunkAnalyticsData } = await import(`${getUnityLibs()}/utils/chunkingUtils.js`);
+        const totalChunks = Math.ceil(file.size / blocksize);
+        this.logAnalyticsinSplunk(
+          'Chunked Upload Completed|UnityWidget',
+          createChunkAnalyticsData('Chunked Upload Completed|UnityWidget', {
+            assetId: this.assetId,
+            chunkCount: totalChunks,
+            totalFileSize: file.size,
+            fileType: file.type,
+          }),
+        );
       } else {
-        await this.uploadImgToUnity(href, id, file, file.type);
-        this.scanImgForSafety(this.assetId);
+        await this.uploadImgToUnity(href, id, file, file.type, signal);
+        await this.scanImgForSafety(this.assetId, signal);
+        this.logAnalyticsinSplunk('Upload Completed|UnityWidget', { assetId: this.assetId });
       }
       return true;
     } catch (e) {
+      if (this.uploadAbortController?.signal.aborted || e.name === 'AbortError') {
+        window.lana?.log(`Message: Upload aborted, Error: ${e.message}`, this.lanaOptions);
+        return false;
+      }
       const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
       this.transitionScreen = new TransitionScreen(this.transitionScreen.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg, this.desktop);
       await this.transitionScreen.showSplashScreen();

--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -218,7 +218,7 @@ export default class ActionBinder {
           });
           throw error;
         }
-        await this.scanImgForSafety(this.assetId, signal);
+        await uploadHandler.scanImgForSafetyWithRetry(this.assetId, signal);        
         const { createChunkAnalyticsData } = await import(`${getUnityLibs()}/utils/chunkingUtils.js`);
         const totalChunks = Math.ceil(file.size / blocksize);
         this.logAnalyticsinSplunk(

--- a/unitylibs/core/workflow/workflow-upload/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-upload/upload-handler.js
@@ -76,17 +76,7 @@ export default class UploadHandler {
     );
     const { failedChunks, attemptMap } = result;
     const totalChunks = Math.ceil(file.size / blockSize);
-    if (failedChunks.size === 0) {
-      this.actionBinder.logAnalyticsinSplunk(
-        'Chunked Upload Completed|UnityWidget',
-        createChunkAnalyticsData('Chunked Upload Completed|UnityWidget', {
-          assetId: this.actionBinder.assetId,
-          chunkCount: totalChunks,
-          totalFileSize: file.size,
-          fileType: file.type,
-        }),
-      );
-    } else {
+    if (failedChunks.size > 0) {
       this.actionBinder.logAnalyticsinSplunk(
         'Chunked Upload Failed|UnityWidget',
         createChunkAnalyticsData('Chunked Upload Failed|UnityWidget', {
@@ -100,9 +90,14 @@ export default class UploadHandler {
     return { failedChunks, attemptMap };
   }
 
-  async scanImgForSafetyWithRetry(assetId) {
+  async scanImgForSafetyWithRetry(assetId, signal = null) {
     const assetData = { assetId, targetProduct: this.actionBinder.workflowCfg.productName };
-    const postOpts = await getApiCallOptions('POST', unityConfig.apiKey, this.actionBinder.getAdditionalHeaders() || {}, { body: JSON.stringify(assetData) });
+    const postOpts = await getApiCallOptions(
+      'POST',
+      unityConfig.apiKey,
+      this.actionBinder.getAdditionalHeaders() || {},
+      { body: JSON.stringify(assetData), ...(signal && { signal }) },
+    );
     const retryConfig = {
       retryType: 'polling',
       retryParams: {


### PR DESCRIPTION
1. Moved the sending of uploaded event after the finalise call
2. Added abortController to propagate the abort downstream

Note: Even now if the user clicks cancel right at the very end (after finalise call), both cancel and uploaded event will go. However it is reduced to a very small window now. 

Resolves: [MWPW-190479](https://jira.corp.adobe.com/browse/MWPW-190479)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/products/firefly/features/remove-object-from-photo?unitylibs=stage
- After: https://main--cc--adobecom.aem.page/products/firefly/features/remove-object-from-photo?unitylibs=arbugs
