### PR TITLE
[MWPW-191323] updating hero-marquee container css

### DIFF
--- a/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.css
+++ b/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.css
@@ -1316,6 +1316,19 @@
 }
 
 @media screen and (min-width: 1200px) {
+  .hero-marquee:has(+ .unity-prompt-bar-style) > .foreground {
+    max-width: 1000px;
+    min-width: unset;
+  }
+
+  .hero-marquee:has(+ .unity-prompt-bar-style) .foreground .main-copy {
+    align-items: center;
+  }
+
+  .hero-marquee:has(+ .unity-prompt-bar-style) .foreground .main-copy p {
+    max-width: 800px;
+  }
+
   .hero-marquee:has(+ .unity-prompt-bar-style) .foreground .copy h1 {
     font-size: 64px;
     letter-spacing: -1.92px;


### PR DESCRIPTION
Did Below requested changes from design team
1. increase max-width of h2 heading to 1000px
2. keeping the max-width to 800px of the text below it.

Resolves: [MWPW-191323](https://jira.corp.adobe.com/browse/MWPW-191323)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/products/firefly/features/ai-face-generator?unitylibs=MWPW-191323
- After: https://main--cc--adobecom.aem.page/products/firefly/features/ai-face-generator?unitylibs=MWPW-191323-1
