### PR TITLE
[MWPW-190702]Support for new block but target test on acrobat frictionless verbs

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -71,5 +71,18 @@
       ".foreground": "upload",
       "#file-upload": "upload"
     }
+    "verb-marquee": {
+    "selector": ".foreground",
+    "source": ".foreground .verb-marquee-container",
+    "target": ".foreground .verb-marquee-container",
+    "showSplashScreen": true,
+    "splashScreenConfig": {
+      "fragmentLink": "/dc-shared/fragments/shared-fragments/frictionless/splash-page/splashscreen",
+      "splashScreenParent": "body"
+    },
+    "actionMap": {
+      ".foreground": "upload",
+      "#file-upload": "upload"
+    }
   }
 }

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -70,7 +70,7 @@
     "actionMap": {
       ".foreground": "upload",
       "#file-upload": "upload"
-    }
+    },
     "verb-marquee": {
     "selector": ".foreground",
     "source": ".foreground .verb-marquee-container",

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -70,8 +70,9 @@
     "actionMap": {
       ".foreground": "upload",
       "#file-upload": "upload"
-    },
-    "verb-marquee": {
+    }
+  },
+  "verb-marquee": {
     "selector": ".foreground",
     "source": ".foreground .verb-marquee-container",
     "target": ".foreground .verb-marquee-container",

--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -288,7 +288,7 @@ class WfInitiator {
 
   getEnabledFeatures() {
     const { supportedFeatures, supportedTexts } = this.workflowCfg;
-    const verbWidget = this.el.closest('.section')?.querySelector('.verb-widget, .study-marquee');
+    const verbWidget = this.el.closest('.section')?.querySelector('.verb-widget, .study-marquee, .verb-marquee');
     if (verbWidget) {
       const verb = [...verbWidget.classList].find((cn) => supportedFeatures.has(cn));
       if (verb) this.workflowCfg.enabledFeatures.push(verb);


### PR DESCRIPTION
* Support for new block but target test on acrobat frictionless verbs

Resolves: [MWPW-190702](https://jira.corp.adobe.com/browse/MWPW-190702)

**Test URLs:**
- Before: https://ims--da-dc--adobecom.aem.page/acrobat/online/test/unity/target-test/ai-summary-generator?martech=off&unitylibs=stage
- After: https://ims--da-dc--adobecom.aem.page/acrobat/online/test/unity/target-test/ai-summary-generator?martech=off&unitylibs=verb-test
