### PR TITLE
[Release] Stage to Main

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -71,5 +71,19 @@
       ".foreground": "upload",
       "#file-upload": "upload"
     }
+  },
+  "verb-marquee": {
+    "selector": ".foreground",
+    "source": ".foreground .verb-marquee-container",
+    "target": ".foreground .verb-marquee-container",
+    "showSplashScreen": true,
+    "splashScreenConfig": {
+      "fragmentLink": "/dc-shared/fragments/shared-fragments/frictionless/splash-page/splashscreen",
+      "splashScreenParent": "body"
+    },
+    "actionMap": {
+      ".foreground": "upload",
+      "#file-upload": "upload"
+    }
   }
 }

--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -288,7 +288,7 @@ class WfInitiator {
 
   getEnabledFeatures() {
     const { supportedFeatures, supportedTexts } = this.workflowCfg;
-    const verbWidget = this.el.closest('.section')?.querySelector('.verb-widget, .study-marquee');
+    const verbWidget = this.el.closest('.section')?.querySelector('.verb-widget, .study-marquee, .verb-marquee');
     if (verbWidget) {
       const verb = [...verbWidget.classList].find((cn) => supportedFeatures.has(cn));
       if (verb) this.workflowCfg.enabledFeatures.push(verb);

--- a/unitylibs/scripts/errors.js
+++ b/unitylibs/scripts/errors.js
@@ -27,10 +27,8 @@ async function loadErrorMessages(verb) {
   let baseUrl;
   if (origin.includes('.aem.') || origin.includes('.hlx.')) {
     baseUrl = `https://main--unity--adobecom.${origin.includes('.hlx.') ? 'hlx' : 'aem'}.live`;
-  } else if (origin === 'https://stage.acrobat.adobe.com') {
-    baseUrl = 'https://milo.stage.adobe.com';
-  } else if (origin === 'https://acrobat.adobe.com') {
-    baseUrl = 'https://milo.adobe.com';
+  } else if (origin.endsWith('acrobat.adobe.com')) {
+    baseUrl = `${origin}/dc-shared`;
   } else {
     baseUrl = origin;
   }

--- a/unitylibs/scripts/utils.js
+++ b/unitylibs/scripts/utils.js
@@ -3,9 +3,8 @@ export const [setLibs, getLibs] = (() => {
   return [
     (prodLibs, location) => {
       libs = (() => {
-        const { hostname, search } = location || window.location;
-        if (hostname === 'acrobat.adobe.com') return 'https://milo.adobe.com/libs';
-        if (hostname === 'stage.acrobat.adobe.com') return 'https://milo.stage.adobe.com/libs';
+        const { hostname, origin, search } = location || window.location;
+        if (hostname.endsWith('acrobat.adobe.com')) return `${origin}/dc-shared/libs`;
         if (!(hostname.includes('.hlx.') || hostname.includes('.aem.') || hostname.includes('local'))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
         if (branch === 'local') return 'http://localhost:6456/libs';


### PR DESCRIPTION
* https://github.com/adobecom/unity/pull/719
* https://github.com/adobecom/unity/pull/733


**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/acrobat/online/compress-pdf?martech=off&unitylibs=main
- After: https://stage--da-dc--adobecom.aem.page/acrobat/online/compress-pdf?martech=off&unitylibs=stage

- Before: https://main--da-dc--adobecom.aem.page/acrobat/online/quiz-maker?martech=off&unitylibs=main
- After: https://stage--da-dc--adobecom.aem.page/acrobat/online/flashcard-maker?martech=off&unitylibs=stage

- Before: https://main--dc-frictionless--adobecom.aem.page/heic-to-pdf?martech=off&unitylibs=main
- After: https://stage--dc-frictionless--adobecom.aem.page/heic-to-pdf?martech=off&unitylibs=stage


**Testing Note:**

This is acrobat workflow specific release.
Please do a regression across frictionless verbs and student spaces verbs on stage.adobe.com and heic to pdf on stage.acrobat.adobe.com
