### PR TITLE
[MWPW-190483] Fixing error observed in analytics + console errors on clicking cancel

### DIFF
--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -121,8 +121,10 @@ export default class ActionBinder {
       this.uploadAbortController?.abort();
       sendAnalyticsEvent(new CustomEvent('Cancel|UnityWidget'));
       this.logAnalyticsinSplunk('Cancel|UnityWidget', { assetId: this.assetId });
-      const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
-      this.transitionScreen = new TransitionScreen(this.transitionScreen.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg, this.desktop);
+      if (!this.transitionScreen) {
+        const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
+        this.transitionScreen = new TransitionScreen(this.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg, this.desktop);
+      }
       await this.transitionScreen.showSplashScreen();
       const e = new Error('Operation termination requested.');
       const cancelPromise = Promise.reject(e);
@@ -241,8 +243,10 @@ export default class ActionBinder {
         window.lana?.log(`Message: Upload aborted, Error: ${e.message}`, this.lanaOptions);
         return false;
       }
-      const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
-      this.transitionScreen = new TransitionScreen(this.transitionScreen.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg, this.desktop);
+      if (!this.transitionScreen) {
+        const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
+        this.transitionScreen = new TransitionScreen(this.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg, this.desktop);
+      }
       await this.transitionScreen.showSplashScreen();
       this.serviceHandler.showErrorToast({ errorToastEl: this.errorToastEl, errorType: '.icon-error-request' }, e, this.lanaOptions);
       this.logAnalyticsinSplunk('Upload server error|UnityWidget', {
@@ -321,9 +325,12 @@ export default class ActionBinder {
       payload,
     };
     try {
-      const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
+      if (!this.transitionScreen) {
+        const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
+        this.transitionScreen = new TransitionScreen(this.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg, this.desktop);
+      }
       this.LOADER_LIMIT = 100;
-      this.transitionScreen = new TransitionScreen(this.transitionScreen.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg, this.desktop);
+      this.transitionScreen.LOADER_LIMIT = 100;
       this.transitionScreen.updateProgressBar(this.transitionScreen.splashScreenEl, 100);
       const servicePromise = this.serviceHandler.postCallToService(
         this.apiConfig.connectorApiEndPoint,
@@ -415,8 +422,10 @@ export default class ActionBinder {
       const { default: isDesktop } = await import(`${getUnityLibs()}/utils/device-detection.js`);
       this.desktop = isDesktop();
     }
-    const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
-    this.transitionScreen = new TransitionScreen(this.transitionScreen.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg, this.desktop);
+    if (!this.transitionScreen) {
+      const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
+      this.transitionScreen = new TransitionScreen(this.splashScreenEl, this.initActionListeners, this.LOADER_LIMIT, this.workflowCfg, this.desktop);
+    }
     await this.transitionScreen.showSplashScreen(true);
     const uploadSuccess = await this.uploadAsset(file);
     if (uploadSuccess) await this.continueInApp(this.assetId, file);

--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -119,6 +119,7 @@ export default class ActionBinder {
   async cancelUploadOperation() {
     try {
       this.uploadAbortController?.abort();
+      this.uploadAbortController = null;
       sendAnalyticsEvent(new CustomEvent('Cancel|UnityWidget'));
       this.logAnalyticsinSplunk('Cancel|UnityWidget', { assetId: this.assetId });
       if (!this.transitionScreen) {
@@ -128,6 +129,7 @@ export default class ActionBinder {
       await this.transitionScreen.showSplashScreen();
       const e = new Error('Operation termination requested.');
       const cancelPromise = Promise.reject(e);
+      cancelPromise.catch(() => {});
       this.promiseStack.unshift(cancelPromise);
     } catch (error) {
       await this.transitionScreen?.showSplashScreen();
@@ -211,6 +213,7 @@ export default class ActionBinder {
       if (blocksize && uploadUrls && Array.isArray(uploadUrls)) {
         const { failedChunks, attemptMap } = await uploadHandler.uploadChunksToUnity(uploadUrls, file, blocksize, signal);
         if (failedChunks && failedChunks.size > 0) {
+          if (signal.aborted) return false;
           const error = new Error(`One or more chunks failed to upload for asset: ${id}, ${file.size} bytes, ${file.type}`);
           error.status = 504;
           this.logAnalyticsinSplunk('Chunked Upload Failed|UnityWidget', {
@@ -239,7 +242,7 @@ export default class ActionBinder {
       }
       return true;
     } catch (e) {
-      if (this.uploadAbortController?.signal.aborted || e.name === 'AbortError') {
+      if (signal.aborted || e.name === 'AbortError') {
         window.lana?.log(`Message: Upload aborted, Error: ${e.message}`, this.lanaOptions);
         return false;
       }

--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -30,7 +30,17 @@ class ServiceHandler {
       headers: await getHeaders(unityConfig.apiKey, this.getAdditionalHeaders?.() || {}),
       ...options,
     };
-    const response = await fetch(api, postOpts);
+    let response;
+    try {
+      response = await fetch(api, postOpts);
+    } catch (e) {
+      if (e instanceof TypeError) {
+        const error = new Error(`Network error. URL: ${api}; Error message: ${e.message}`);
+        error.status = 0;
+        throw error;
+      }
+      throw e;
+    }
     if (failOnError && response.status !== 200) {
       const error = new Error('Operation failed');
       error.status = response.status;
@@ -157,7 +167,17 @@ export default class ActionBinder {
       body: blobData,
       ...(signal && { signal }),
     };
-    const response = await fetch(storageUrl, uploadOptions);
+    let response;
+    try {
+      response = await fetch(storageUrl, uploadOptions);
+    } catch (e) {
+      if (e instanceof TypeError) {
+        const error = new Error(`Network error. URL: ${storageUrl}; Error message: ${e.message}`);
+        error.status = 0;
+        throw error;
+      }
+      throw e;
+    }
     if (response.status !== 200) {
       window.lana?.log(`Message: Failed to upload image to Unity, Error: ${response.status}`, this.lanaOptions);
       const error = new Error('Failed to upload image to Unity');

--- a/unitylibs/core/workflow/workflow-upload/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-upload/upload-handler.js
@@ -47,15 +47,17 @@ export default class UploadHandler {
       throw error;
     };
     const onError = (error) => {
-      this.logError('Upload Chunk Error|UnityWidget', {
-        chunkNumber,
-        size: blobData.size,
-        fileType,
-        errorData: {
-          code: 'upload-chunk-error',
-          desc: `Exception during chunk ${chunkNumber} upload: ${error.message}`,
-        },
-      }, `Message: Exception raised when uploading chunk to Unity, Error: ${error.message}, Asset ID: ${assetId}, ${blobData.size} bytes`);
+      if (error.name !== 'AbortError') {
+        this.logError('Upload Chunk Error|UnityWidget', {
+          chunkNumber,
+          size: blobData.size,
+          fileType,
+          errorData: {
+            code: 'upload-chunk-error',
+            desc: `Exception during chunk ${chunkNumber} upload: ${error.message}`,
+          },
+        }, `Message: Exception raised when uploading chunk to Unity, Error: ${error.message}, Asset ID: ${assetId}, ${blobData.size} bytes`);
+      }
       throw error;
     };
     return this.networkUtils.fetchFromServiceWithRetry(storageUrl, uploadOptions, retryConfig, onSuccess, onError);
@@ -76,7 +78,7 @@ export default class UploadHandler {
     );
     const { failedChunks, attemptMap } = result;
     const totalChunks = Math.ceil(file.size / blockSize);
-    if (failedChunks.size > 0) {
+    if (failedChunks.size > 0 && !signal?.aborted) {
       this.actionBinder.logAnalyticsinSplunk(
         'Chunked Upload Failed|UnityWidget',
         createChunkAnalyticsData('Chunked Upload Failed|UnityWidget', {

--- a/unitylibs/scripts/transition-screen.js
+++ b/unitylibs/scripts/transition-screen.js
@@ -31,6 +31,7 @@ export default class TransitionScreen {
   }
 
   updateProgressBar(layer, percentage) {
+    if (!layer) return;
     if (!this.progressText && TransitionScreen.lastProgressText) this.progressText = TransitionScreen.lastProgressText;
     const p = Math.min(percentage, this.LOADER_LIMIT);
     const spb = layer.querySelector('.spectrum-ProgressBar');

--- a/unitylibs/utils/NetworkUtils.js
+++ b/unitylibs/utils/NetworkUtils.js
@@ -146,8 +146,10 @@ export default class NetworkUtils {
       }
       return await this.afterFetchFromService(url, response);
     } catch (error) {
-      if (error) error.message += `, Max retry delay exceeded for URL: ${url}`;
-      else error = new Error(`Max retry delay exceeded for URL: ${url}`);
+      if (timeLapsed >= maxRetryDelay) {
+        if (error) error.message += `, Max retry delay exceeded for URL: ${url}`;
+        else error = new Error(`Max retry delay exceeded for URL: ${url}`);
+      }
       throw error;
     }
   }

--- a/unitylibs/utils/chunkingUtils.js
+++ b/unitylibs/utils/chunkingUtils.js
@@ -54,6 +54,7 @@ export async function createChunkUploadTasks(uploadUrls, file, blockSize, upload
         throw err;
       }
     })();
+    uploadPromise.catch(() => {});
     uploadPromises.push(uploadPromise);
   }
   if (signal?.aborted) return { failedChunks, attemptMap };


### PR DESCRIPTION
  1. Changed all TransitionScreen instantiation sites to be lazy — only creates a new TransitionScreen instance if one doesn't already exist (if (!this.transitionScreen)). Also fixes a bug where this.transitionScreen.splashScreenEl was used (referencing the old object) instead of this.splashScreenEl, and updates LOADER_LIMIT on the existing instance rather than re-constructing.
2. Improved error logging to clearly distinguish between different server failures. Currently there were wrong messaging logged for few errors. 
3. Fixed console error on clicking cancel. (EPV)

<img width="517" height="73" alt="image" src="https://github.com/user-attachments/assets/973ebac1-d3fe-4f82-8c75-f0fa8ba71b31" />


Resolves: [MWPW-190483](https://jira.corp.adobe.com/browse/MWPW-190483)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/products/firefly/features/remove-object-from-photo?unitylibs=stage
- After: https://main--cc--adobecom.aem.page/products/firefly/features/remove-object-from-photo?unitylibs=followups
