### PR TITLE
MWPW-192625 Add original verb query param

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -457,7 +457,9 @@ export default class ActionBinder {
             redirectUrl = url.href;
           }
         }
-        this.redirectUrl = redirectUrl;        
+        const finalUrl = new URL(redirectUrl);
+        finalUrl.searchParams.set('originalVerb', this.workflowCfg.enabledFeatures[0]);
+        this.redirectUrl = finalUrl.href;
       })
       .catch(async (e) => {
         await this.showTransitionScreen();


### PR DESCRIPTION
* Adds `originalVerb` query param to redirect URL for appropriate verb attribution

Resolves: [MWPW-192625](https://jira.corp.adobe.com/browse/MWPW-192625)

**Test URLs:**
- Before: https://main--dc--adobecom.aem.page/acrobat/online/word-to-pdf?unitylibs=stage
- After: https://main--dc--adobecom.aem.page/acrobat/online/word-to-pdf?unitylibs=acrobat-queryparam

**Testing Details**

1. Visit the test URL and upload a non-Word file such as PPT
2. You should be transferred to PPT to pdf in product
3. Verify that the redirect URL looks like the following where `originalVerb` query param has been included pointing to the original verb page we started the upload from. (https://stage.acrobat.adobe.com/us/en/ppt-to-pdf?unitylibs=acrobat-queryparam&x_api_client_id=unity&x_api_client_location=ppt-to-pdf&user=frictionless_return_user&attempts=2nd&originalVerb=word-to-pdf)