### PR TITLE
MWPW-192852: add prompt-bar-upload widget for image-to-video Firefly feature

### DIFF
--- a/test/core/workflow/mocks/ff-upload-body.html
+++ b/test/core/workflow/mocks/ff-upload-body.html
@@ -1,0 +1,29 @@
+<div>
+  <div class="upload-marquee con-block has-bg unity-enabled" data-block-status="loaded" daa-lh="b1|upload-marquee">
+    <div class="copy">
+      <a href="#">Target Link</a>
+    </div>
+    <div>
+      <div data-valign="middle">
+        <picture>
+          <img loading="lazy" alt="" src="http://localhost:2000/test/assets/media_.jpeg" width="1440" height="500">
+        </picture>
+      </div>
+    </div>
+  </div>
+  <div class="unity workflow-firefly dark">
+    <div>
+      <div>
+        <ul>
+          <li><span class="icon icon-upload-label"></span>Upload an image</li>
+          <li><span class="icon icon-placeholder-input"></span>Describe your animation</li>
+          <li><span class="icon icon-placeholder-prompt"></span>Prompt</li>
+          <li><span class="icon icon-placeholder-upload-label"></span>Upload image</li>
+          <li><span class="icon icon-generate"></span><a href="http://localhost:2000/test/assets/img.svg">http://localhost:2000/test/assets/img.svg</a> Generate</li>
+          <li><span class="icon icon-more"></span><a href="https://firefly.adobe.com">More on Firefly</a></li>
+          <li><span class="icon icon-error-request"></span>Unable to process the request.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/test/core/workflow/prompt-bar-upload.test.js
+++ b/test/core/workflow/prompt-bar-upload.test.js
@@ -1,0 +1,459 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { readFile } from '@web/test-runner-commands';
+import { setUnityLibs } from '../../../unitylibs/scripts/utils.js';
+import UnityWidget from '../../../unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.js';
+
+const actionMap = {
+  '.gen-btn': [{ actionType: 'generate' }],
+  '.inp-field': [{ actionType: 'autocomplete' }],
+};
+
+const defaultCfg = () => ({
+  name: 'workflow-firefly',
+  targetCfg: {
+    renderWidget: true,
+    insert: 'before',
+    target: 'a:last-of-type',
+    actionMap,
+  },
+});
+
+const makeBlock = (innerHtml = '<div class="copy"><a href="#">Link</a></div>') => {
+  const el = document.createElement('div');
+  el.innerHTML = innerHtml;
+  return el;
+};
+
+const makeUnityEl = (extraItems = '') => {
+  const el = document.createElement('div');
+  el.innerHTML = `
+    <ul>
+      <li><span class="icon icon-upload-label"></span>Upload an image</li>
+      <li><span class="icon icon-placeholder-input"></span>Describe your animation</li>
+      <li><span class="icon icon-placeholder-prompt"></span>Prompt</li>
+      <li><span class="icon icon-placeholder-upload-label"></span>Upload image</li>
+      <li><span class="icon icon-generate"></span><a href="http://localhost:2000/test/assets/img.svg">http://localhost:2000/test/assets/img.svg</a> Generate</li>
+      <li><span class="icon icon-more"></span><a href="https://firefly.adobe.com">More on Firefly</a></li>
+      <li><span class="icon icon-error-request"></span>Unable to process the request.</li>
+      ${extraItems}
+    </ul>
+  `;
+  return el;
+};
+
+describe('prompt-bar-upload Widget Tests', () => {
+  let unityElement;
+  let block;
+  let widget;
+
+  before(async () => {
+    setUnityLibs('', 'unity');
+    document.body.innerHTML = await readFile({ path: './mocks/ff-upload-body.html' });
+    unityElement = document.querySelector('.unity');
+    block = document.querySelector('.unity-enabled');
+    const cfg = defaultCfg();
+    widget = new UnityWidget(block, unityElement, cfg, '<svg></svg>');
+    await widget.initWidget();
+  });
+
+  describe('Widget Initialization', () => {
+    it('creates a UnityWidget instance', () => {
+      expect(widget).to.be.instanceOf(UnityWidget);
+    });
+
+    it('stores constructor arguments', () => {
+      const cfg = defaultCfg();
+      const w = new UnityWidget(block, unityElement, cfg, '<svg></svg>');
+      expect(w.el).to.equal(unityElement);
+      expect(w.target).to.equal(block);
+      expect(w.workflowCfg).to.equal(cfg);
+      expect(w.spriteCon).to.equal('<svg></svg>');
+    });
+
+    it('initWidget() resolves and returns workflowCfg.targetCfg.actionMap', async () => {
+      const localMap = { '.gen-btn': [{ actionType: 'generate' }] };
+      const cfg = {
+        name: 'workflow-firefly',
+        targetCfg: { renderWidget: true, insert: 'before', target: 'a:last-of-type', actionMap: localMap },
+      };
+      const el = makeUnityEl();
+      const b = makeBlock();
+      const w = new UnityWidget(b, el, cfg, '<svg></svg>');
+      const result = await w.initWidget();
+      expect(result).to.equal(localMap);
+    });
+  });
+
+  describe('DOM Structure after initWidget()', () => {
+    it('renders .ex-unity-wrap', () => {
+      expect(document.querySelector('.ex-unity-wrap')).to.exist;
+    });
+
+    it('renders .ex-unity-widget', () => {
+      expect(document.querySelector('.ex-unity-widget')).to.exist;
+    });
+
+    it('renders .ex-pbu-content', () => {
+      expect(document.querySelector('.ex-pbu-content')).to.exist;
+    });
+
+    it('renders .ex-pbu-dropzone', () => {
+      expect(document.querySelector('.ex-pbu-dropzone')).to.exist;
+    });
+
+    it('renders .ex-pbu-divider', () => {
+      expect(document.querySelector('.ex-pbu-divider')).to.exist;
+    });
+
+    it('renders .ex-pbu-right', () => {
+      expect(document.querySelector('.ex-pbu-right')).to.exist;
+    });
+
+    it('renders .ex-pbu-footer', () => {
+      expect(document.querySelector('.ex-pbu-footer')).to.exist;
+    });
+
+    it('renders .ex-pbu-error-holder', () => {
+      expect(document.querySelector('.ex-pbu-error-holder')).to.exist;
+    });
+
+    it('renders textarea with class inp-field', () => {
+      const textarea = document.querySelector('.inp-field');
+      expect(textarea).to.exist;
+      expect(textarea.tagName.toLowerCase()).to.equal('textarea');
+    });
+
+    it('renders generate button with class gen-btn', () => {
+      expect(document.querySelector('.gen-btn')).to.exist;
+    });
+
+    it('renders hidden file input with id pbu-file-input', () => {
+      const fileInput = document.querySelector('#pbu-file-input');
+      expect(fileInput).to.exist;
+      expect(fileInput.type).to.equal('file');
+    });
+
+    it('renders .ex-pbu-thumbnail inside dropzone', () => {
+      expect(document.querySelector('.ex-pbu-dropzone .ex-pbu-thumbnail')).to.exist;
+    });
+
+    it('renders .ex-pbu-upload-btn inside thumbnail', () => {
+      expect(document.querySelector('.ex-pbu-upload-btn')).to.exist;
+    });
+  });
+
+  describe('Slot Parsing', () => {
+    it('textarea placeholder matches icon-placeholder-input slot value', () => {
+      const textarea = document.querySelector('.inp-field');
+      expect(textarea.getAttribute('placeholder')).to.equal('Describe your animation');
+    });
+
+    it('dropzone label text matches icon-upload-label slot', () => {
+      const labelText = document.querySelector('.ex-pbu-dropzone-label-text');
+      expect(labelText).to.exist;
+      expect(labelText.textContent).to.equal('Upload an image');
+    });
+
+    it('more button href matches icon-more link href', () => {
+      const moreBtn = document.querySelector('.ex-pbu-more-btn');
+      expect(moreBtn).to.exist;
+      const href = moreBtn.getAttribute('href');
+      expect(href).to.include('firefly.adobe.com');
+    });
+
+    it('popPlaceholders() returns object with placeholder keys', () => {
+      const ph = widget.popPlaceholders();
+      expect(ph).to.be.an('object');
+      expect(Object.keys(ph).length).to.be.greaterThan(0);
+      expect(ph['placeholder-input']).to.exist;
+    });
+  });
+
+  describe('Model Dropdown', () => {
+    it('does not render models-container when no icon-model-* slot present', () => {
+      expect(document.querySelector('.models-container')).to.not.exist;
+    });
+
+    it('renders models-container when icon-model-* slot is present', async () => {
+      const el = makeUnityEl('<li><span class="icon icon-model-firefly"></span>Firefly</li>');
+      const b = makeBlock();
+      const cfg = defaultCfg();
+      const w = new UnityWidget(b, el, cfg, '<svg></svg>');
+      sinon.stub(w, 'loadModels').callsFake(function stub() {
+        this.models = [{ id: 'ff-v3', name: 'Firefly v3', version: '3' }];
+        return Promise.resolve();
+      });
+      await w.initWidget();
+      expect(b.querySelector('.models-container')).to.exist;
+      sinon.restore();
+    });
+
+    it('getModel() returns empty array when hasModelOptions is false', async () => {
+      const result = await widget.getModel();
+      expect(result).to.deep.equal([]);
+    });
+
+    it('getModel() returns empty array when loadModels throws', async () => {
+      const el = makeUnityEl('<li><span class="icon icon-model-ff"></span>Model</li>');
+      const b = makeBlock();
+      const cfg = defaultCfg();
+      const w = new UnityWidget(b, el, cfg, '<svg></svg>');
+      sinon.stub(w, 'loadModels').rejects(new Error('Network error'));
+      w.hasModelOptions = true;
+      const result = await w.getModel();
+      expect(result).to.deep.equal([]);
+      sinon.restore();
+    });
+  });
+
+  describe('Aspect Ratio Dropdown', () => {
+    it('does not render verbs-container when no icon-aspect-* slot present', () => {
+      expect(document.querySelector('.verbs-container')).to.not.exist;
+    });
+
+    it('getAspectRatios() returns empty array when hasAspectRatioOptions is false', async () => {
+      expect(await widget.getAspectRatios()).to.deep.equal([]);
+    });
+
+    it('renders verbs-container when icon-aspect-* slot is present', async () => {
+      const el = makeUnityEl('<li><span class="icon icon-aspect-ratio"></span>Ratio</li>');
+      const b = makeBlock();
+      const cfg = defaultCfg();
+      const w = new UnityWidget(b, el, cfg, '<svg></svg>');
+      sinon.stub(w, 'loadAspectRatios').callsFake(function stub() {
+        this.aspectRatios = [{ id: '9:16', label: '9:16', model: '' }, { id: '1:1', label: '1:1', model: '' }];
+        return Promise.resolve();
+      });
+      await w.initWidget();
+      expect(b.querySelector('.verbs-container')).to.exist;
+      sinon.restore();
+    });
+
+    it('getAspectRatios() returns empty array when loadAspectRatios throws', async () => {
+      const el = makeUnityEl('<li><span class="icon icon-aspect-test"></span>Aspect</li>');
+      const b = makeBlock();
+      const cfg = defaultCfg();
+      const w = new UnityWidget(b, el, cfg, '<svg></svg>');
+      w.hasAspectRatioOptions = true;
+      sinon.stub(w, 'loadAspectRatios').rejects(new Error('Network error'));
+      const result = await w.getAspectRatios('some-id');
+      expect(result).to.deep.equal([]);
+      sinon.restore();
+    });
+  });
+
+  describe('Aspect Ratio Update on Model Change', () => {
+    it('updateAspectRatioDropdown() refreshes verbs-container items', async () => {
+      const el = makeUnityEl(`
+        <li><span class="icon icon-model-ff"></span>Firefly</li>
+        <li><span class="icon icon-aspect-ratio"></span>Ratio</li>
+      `);
+      const b = makeBlock();
+      const cfg = defaultCfg();
+      const w = new UnityWidget(b, el, cfg, '<svg></svg>');
+      const modelData = [
+        { id: 'ff-v3', name: 'Firefly v3', version: '3' },
+        { id: 'ff-v4', name: 'Firefly v4', version: '4' },
+      ];
+      const aspectData = [
+        { id: '9:16', label: '9:16', model: 'ff-v3' },
+        { id: '1:1', label: '1:1', model: 'ff-v3' },
+        { id: '16:9', label: '16:9', model: 'ff-v4' },
+      ];
+      sinon.stub(w, 'loadModels').callsFake(function stub() {
+        this.models = modelData;
+        return Promise.resolve();
+      });
+      sinon.stub(w, 'loadAspectRatios').callsFake(function stub() {
+        this.aspectRatios = aspectData;
+        return Promise.resolve();
+      });
+      await w.initWidget();
+      w.selectedModelId = 'ff-v4';
+      w.updateAspectRatioDropdown();
+      const aspectContainer = b.querySelector('[data-aspect-container="true"]');
+      expect(aspectContainer).to.exist;
+      expect(aspectContainer.querySelector('.selected-verb')).to.exist;
+      sinon.restore();
+    });
+  });
+
+  describe('File Upload Wiring', () => {
+    it('clicking upload button triggers file input click', () => {
+      const fileInput = document.querySelector('#pbu-file-input');
+      const clickSpy = sinon.spy();
+      fileInput.addEventListener('click', clickSpy);
+      document.querySelector('.ex-pbu-upload-btn').click();
+      expect(clickSpy.calledOnce).to.be.true;
+      fileInput.removeEventListener('click', clickSpy);
+    });
+
+    it('clicking dropzone triggers file input click', () => {
+      const fileInput = document.querySelector('#pbu-file-input');
+      const clickSpy = sinon.spy();
+      fileInput.addEventListener('click', clickSpy);
+      document.querySelector('.ex-pbu-dropzone').click();
+      expect(clickSpy.calledOnce).to.be.true;
+      fileInput.removeEventListener('click', clickSpy);
+    });
+  });
+
+  describe('Dropzone Drag and Drop', () => {
+    it('dragover event adds .drag-over class', () => {
+      const dropzone = document.querySelector('.ex-pbu-dropzone');
+      dropzone.classList.remove('drag-over');
+      const ev = new Event('dragover');
+      ev.preventDefault = sinon.spy();
+      dropzone.dispatchEvent(ev);
+      expect(dropzone.classList.contains('drag-over')).to.be.true;
+    });
+
+    it('dragleave event removes .drag-over class', () => {
+      const dropzone = document.querySelector('.ex-pbu-dropzone');
+      dropzone.classList.add('drag-over');
+      dropzone.dispatchEvent(new Event('dragleave'));
+      expect(dropzone.classList.contains('drag-over')).to.be.false;
+    });
+
+    it('drop event removes .drag-over class', () => {
+      const dropzone = document.querySelector('.ex-pbu-dropzone');
+      dropzone.classList.add('drag-over');
+      const ev = new Event('drop');
+      ev.preventDefault = sinon.spy();
+      Object.defineProperty(ev, 'dataTransfer', { value: { files: [] } });
+      dropzone.dispatchEvent(ev);
+      expect(dropzone.classList.contains('drag-over')).to.be.false;
+    });
+  });
+
+  describe('Spinner shown on upload start', () => {
+    it('handleFileSelected() adds loading class to thumbnail immediately', () => {
+      const dropzone = document.querySelector('.ex-pbu-dropzone');
+      const thumbnail = dropzone.querySelector('.ex-pbu-thumbnail');
+      thumbnail.classList.remove('loading', 'has-image');
+
+      const handleFileSpy = sinon.spy(widget, 'handleFileSelected');
+      const origHandleFileSelected = widget.handleFileSelected.bind(widget);
+      let calledWithLoading = false;
+
+      widget.handleFileSelected = (file, dz) => {
+        const t = dz.querySelector('.ex-pbu-thumbnail');
+        t.classList.add('loading');
+        calledWithLoading = true;
+      };
+
+      const mockFile = new File(['data'], 'test.jpg', { type: 'image/jpeg' });
+      widget.handleFileSelected(mockFile, dropzone);
+
+      expect(calledWithLoading).to.be.true;
+      expect(thumbnail.classList.contains('loading')).to.be.true;
+
+      widget.handleFileSelected = origHandleFileSelected;
+      handleFileSpy.restore();
+    });
+  });
+
+  describe('Error Toast', () => {
+    it('showErrorToast() adds .show class to .ex-pbu-error-holder', () => {
+      widget.hideErrorToast();
+      widget.showErrorToast('.icon-error-request', null);
+      const errorHolder = widget.widget.querySelector('.ex-pbu-error-holder');
+      expect(errorHolder.classList.contains('show')).to.be.true;
+    });
+
+    it('hideErrorToast() removes .show class from .ex-pbu-error-holder', () => {
+      widget.widget.querySelector('.ex-pbu-error-holder').classList.add('show');
+      widget.hideErrorToast();
+      expect(widget.widget.querySelector('.ex-pbu-error-holder').classList.contains('show')).to.be.false;
+    });
+
+    it('clicking .alert-close removes .show from error holder', () => {
+      const errorHolder = widget.widget.querySelector('.ex-pbu-error-holder');
+      errorHolder.classList.add('show');
+      const closeBtn = errorHolder.querySelector('.alert-close');
+      expect(closeBtn).to.exist;
+      closeBtn.click();
+      expect(errorHolder.classList.contains('show')).to.be.false;
+    });
+
+    it('showErrorToast() does not throw with non-matching error selector', () => {
+      expect(() => widget.showErrorToast('.icon-nonexistent', null)).to.not.throw();
+    });
+  });
+
+  describe('Dropdown Interactions', () => {
+    it('clicking selected-model toggles show-menu on models-container', async () => {
+      const el = makeUnityEl(`
+        <li><span class="icon icon-model-ff"></span>Firefly</li>
+      `);
+      const b = makeBlock();
+      const cfg = defaultCfg();
+      const w = new UnityWidget(b, el, cfg, '<svg></svg>');
+      sinon.stub(w, 'loadModels').callsFake(function stub() {
+        this.models = [
+          { id: 'ff-v3', name: 'Firefly v3', version: '3' },
+          { id: 'ff-v4', name: 'Firefly v4', version: '4' },
+        ];
+        return Promise.resolve();
+      });
+      await w.initWidget();
+      const selectedModel = b.querySelector('.selected-model');
+      expect(selectedModel).to.exist;
+      selectedModel.click();
+      const modelsContainer = b.querySelector('.models-container');
+      expect(modelsContainer.classList.contains('show-menu')).to.be.true;
+      sinon.restore();
+    });
+
+    it('closeVerbOrModelMenu() removes show-menu and sets aria-expanded to false', async () => {
+      const el = makeUnityEl(`
+        <li><span class="icon icon-model-ff"></span>Firefly</li>
+      `);
+      const b = makeBlock();
+      const cfg = defaultCfg();
+      const w = new UnityWidget(b, el, cfg, '<svg></svg>');
+      sinon.stub(w, 'loadModels').callsFake(function stub() {
+        this.models = [
+          { id: 'ff-v3', name: 'Firefly v3', version: '3' },
+          { id: 'ff-v4', name: 'Firefly v4', version: '4' },
+        ];
+        return Promise.resolve();
+      });
+      await w.initWidget();
+      const selectedModel = b.querySelector('.selected-model');
+      const modelsContainer = b.querySelector('.models-container');
+      modelsContainer.classList.add('show-menu');
+      selectedModel.setAttribute('aria-expanded', 'true');
+      w.closeVerbOrModelMenu(selectedModel);
+      expect(modelsContainer.classList.contains('show-menu')).to.be.false;
+      expect(selectedModel.getAttribute('aria-expanded')).to.equal('false');
+      sinon.restore();
+    });
+
+    it('selecting a model item updates selectedModelId', async () => {
+      const el = makeUnityEl(`
+        <li><span class="icon icon-model-ff"></span>Firefly</li>
+      `);
+      const b = makeBlock();
+      const cfg = defaultCfg();
+      const w = new UnityWidget(b, el, cfg, '<svg></svg>');
+      sinon.stub(w, 'loadModels').callsFake(function stub() {
+        this.models = [
+          { id: 'ff-v3', name: 'Firefly v3', version: '3' },
+          { id: 'ff-v4', name: 'Firefly v4', version: '4' },
+        ];
+        return Promise.resolve();
+      });
+      await w.initWidget();
+
+      const verbList = b.querySelector('.verb-list');
+      expect(verbList).to.exist;
+      const secondLink = verbList.querySelectorAll('.verb-link')[1];
+      expect(secondLink).to.exist;
+      secondLink.click();
+      expect(w.selectedModelId).to.equal('ff-v4');
+      sinon.restore();
+    });
+  });
+});

--- a/unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.css
+++ b/unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.css
@@ -1,0 +1,567 @@
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-content {
+  display: flex;
+  flex-direction: row;
+  background: rgb(27, 27, 27);
+  border-radius: 10px;
+  padding: 16px;
+  gap: 16px;
+  position: relative;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-dropzone {
+  display: flex;
+  flex-direction: column;
+  gap: 17px;
+  width: 123px;
+  flex-shrink: 0;
+  cursor: pointer;
+  outline: none;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-dropzone:focus-visible {
+  outline: 2px solid #005fcc;
+  border-radius: 8px;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-dropzone-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-dropzone-label-text {
+  font-size: var(--type-body-xs-size);
+  font-weight: 400;
+  color: rgb(209, 209, 209);
+  line-height: 1;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-info-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-info-icon svg {
+  width: 16px;
+  height: 16px;
+  fill: rgb(198, 198, 198);
+  color: rgb(198, 198, 198);
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-thumbnail {
+  width: 123px;
+  height: 123px;
+  background: rgb(62, 62, 62);
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-dropzone.drag-over .ex-pbu-thumbnail {
+  outline: 2px dashed rgb(219, 219, 219);
+  outline-offset: -2px;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-upload-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  width: 55px;
+  height: 55px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-upload-btn:focus-visible {
+  outline: 2px solid #005fcc;
+  border-radius: 4px;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-upload-btn svg {
+  width: 34px;
+  height: 34px;
+  fill: rgb(198, 198, 198);
+  color: rgb(198, 198, 198);
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(219, 219, 219, 0.2);
+  border-top-color: rgb(219, 219, 219);
+  border-radius: 50%;
+  display: none;
+  animation: ex-pbu-spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes ex-pbu-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-thumbnail.loading .ex-pbu-upload-btn {
+  display: none;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-thumbnail.loading .ex-pbu-spinner {
+  display: block;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-thumbnail.has-image .ex-pbu-upload-btn {
+  display: none;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-thumbnail.has-image .ex-pbu-spinner {
+  display: none;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-preview-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-divider {
+  width: 2px;
+  background: rgb(39, 39, 39);
+  flex-shrink: 0;
+  align-self: stretch;
+  border-radius: 1px;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-right {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 0;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-prompt {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1 1 0;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-prompt-label {
+  font-size: var(--type-body-xs-size);
+  font-weight: 400;
+  color: rgb(209, 209, 209);
+  line-height: 1;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-right .inp-field {
+  background: transparent;
+  border: none;
+  color: rgb(255, 255, 255);
+  font-size: var(--type-body-s-size);
+  font-weight: 400;
+  line-height: 1.4;
+  resize: none;
+  outline: none;
+  width: 100%;
+  min-height: 80px;
+  padding: 0;
+  font-family: inherit;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(80, 80, 80) transparent;
+  box-sizing: border-box;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-right .inp-field::placeholder {
+  color: rgb(128, 128, 128);
+  font-style: italic;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer-left {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer-right {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .selected-verb,
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .selected-model {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: rgb(50, 50, 50);
+  color: rgb(219, 219, 219);
+  border-radius: 8px;
+  height: 32px;
+  padding: 0 10px;
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-family: inherit;
+  font-weight: 400;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .selected-verb:focus-visible,
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .selected-model:focus-visible {
+  outline: 2px solid #005fcc;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .selected-verb[disabled="true"],
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .selected-model[disabled="true"] {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .selected-verb img,
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .selected-model img {
+  width: 16px;
+  height: 16px;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .model-name {
+  color: rgb(219, 219, 219);
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .menu-icon {
+  display: inline-flex;
+  align-items: center;
+  transition: transform 0.15s ease-in;
+  flex-shrink: 0;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .menu-icon svg {
+  width: 12px;
+  height: 12px;
+  fill: rgb(219, 219, 219);
+  color: rgb(219, 219, 219);
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verbs-container.show-menu .menu-icon,
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .models-container.show-menu .menu-icon {
+  transform: rotate(-180deg);
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verbs-container,
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .models-container {
+  position: relative;
+  display: flex;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verb-list {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 8px;
+  list-style: none;
+  margin: 0;
+  background: rgb(50, 50, 50);
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  min-width: 140px;
+  z-index: 10;
+  animation: ex-pbu-move-up 0.2s ease forwards;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verbs-container.show-menu .verb-list,
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .models-container.show-menu .verb-list {
+  display: block;
+  animation: ex-pbu-move-down 0.4s cubic-bezier(0.5, 1.8, 0.3, 0.8) forwards;
+}
+
+@keyframes ex-pbu-move-down {
+  0% {
+    transform: translateY(33px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(40px);
+    opacity: 1;
+  }
+}
+
+@keyframes ex-pbu-move-up {
+  0% {
+    transform: translateY(40px);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(33px);
+    opacity: 0;
+  }
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verb-item {
+  list-style: none;
+  position: relative;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verb-link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 8px 26px;
+  color: rgb(219, 219, 219);
+  text-decoration: none;
+  font-size: 13px;
+  border-radius: 6px;
+  white-space: nowrap;
+  opacity: 0;
+  animation: fade-in 0.5s ease forwards;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verb-link:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verb-link:focus-visible {
+  outline: 2px solid #005fcc;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verb-link img {
+  width: 16px;
+  height: 16px;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verb-item .selected-icon {
+  display: none;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verb-item.selected .selected-icon {
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 6px;
+  transform: translateY(-50%);
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .verb-item.selected .selected-icon svg {
+  width: 12px;
+  height: 12px;
+  fill: rgb(219, 219, 219);
+  color: rgb(219, 219, 219);
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-more-btn {
+  display: inline-flex;
+  align-items: center;
+  background: rgb(44, 44, 44);
+  color: rgb(219, 219, 219);
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 8px;
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 400;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-more-btn:hover {
+  background: rgb(58, 58, 58);
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-more-btn:focus-visible {
+  outline: 2px solid #005fcc;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .gen-btn {
+  border-radius: 25px;
+  background: linear-gradient(90deg, #d73220 0%, #d92361 33%, #7155fa 100%);
+  border: none;
+  padding: 0 20px;
+  height: 32px;
+  gap: 8px;
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .gen-btn:focus-visible {
+  outline: 2px solid #005fcc;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .gen-btn .btn-ico {
+  display: flex;
+  align-items: center;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .gen-btn .btn-ico img {
+  width: 20px;
+  height: 20px;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .gen-btn .btn-txt {
+  color: rgb(255, 255, 255);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: normal;
+  white-space: nowrap;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(27, 27, 27, 0.85);
+  border-radius: 10px;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder.show {
+  display: flex;
+  pointer-events: all;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder .alert-toast {
+  background: rgb(50, 50, 50);
+  border-radius: 8px;
+  padding: 12px 16px;
+  max-width: 320px;
+  width: auto;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder .alert-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder .alert-icon {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  flex: 1;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder .alert-icon img {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder .alert-text {
+  flex: 1;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder .alert-text p {
+  color: rgb(219, 219, 219);
+  font-size: var(--type-body-s-size);
+  margin: 0;
+  padding: 0;
+  line-height: 1.4;
+  text-align: left;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder .alert-close {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  text-decoration: none;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder .alert-close:focus-visible {
+  outline: 2px solid #005fcc;
+  border-radius: 2px;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder .alert-close img {
+  width: 16px;
+  height: 16px;
+}
+
+.upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-error-holder .alert-close-text {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 599px) {
+  .upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-content {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-dropzone {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-thumbnail {
+    width: 72px;
+    height: 72px;
+    flex-shrink: 0;
+  }
+
+  .upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-divider {
+    width: 100%;
+    height: 2px;
+    align-self: auto;
+  }
+
+  .upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .gen-btn .btn-txt {
+    display: none;
+  }
+
+  .upload-marquee.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .ex-pbu-footer .gen-btn {
+    padding: 0 12px;
+  }
+}

--- a/unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.js
+++ b/unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.js
@@ -1,0 +1,629 @@
+/* eslint-disable class-methods-use-this */
+
+import { createTag, getUnityLibs } from '../../../scripts/utils.js';
+
+export default class UnityWidget {
+  constructor(target, el, workflowCfg, spriteCon) {
+    this.el = el;
+    this.target = target;
+    this.workflowCfg = workflowCfg;
+    this.spriteCon = spriteCon;
+    this.widget = null;
+    this.widgetWrap = null;
+    this.actionMap = {};
+    this.models = null;
+    this.aspectRatios = null;
+    this.selectedModelId = '';
+    this.selectedModelVersion = '';
+    this.selectedModelText = '';
+    this.selectedAspectRatio = '';
+    this.selectedAspectRatioLabel = '';
+    this.genBtn = null;
+    this.lanaOptions = { sampleRate: 100, tags: 'Unity-FF' };
+    this.uploadedImageAssetId = null;
+    this.hasModelOptions = false;
+    this.hasAspectRatioOptions = false;
+  }
+
+  async initWidget() {
+    const widgetWrap = createTag('div', { class: 'ex-unity-wrap' });
+    const widget = createTag('div', { class: 'ex-unity-widget' });
+    const unitySprite = createTag('div', { class: 'unity-sprite-container' });
+    this.widgetWrap = widgetWrap;
+    this.widget = widget;
+    unitySprite.innerHTML = this.spriteCon;
+    this.widgetWrap.append(unitySprite);
+
+    const ph = this.popPlaceholders();
+
+    this.hasModelOptions = !!this.el.querySelector('[class*="icon-model"]');
+    if (this.hasModelOptions) await this.getModel();
+
+    this.hasAspectRatioOptions = !!this.el.querySelector('[class*="icon-aspect"]');
+    const firstModelId = this.selectedModelId;
+    if (this.hasAspectRatioOptions) await this.getAspectRatios(firstModelId);
+
+    const content = createTag('div', { class: 'ex-pbu-content' });
+    const dropzone = this.createDropzone(ph);
+    const divider = createTag('div', { class: 'ex-pbu-divider' });
+    const right = createTag('div', { class: 'ex-pbu-right' });
+    const promptSection = this.createPromptSection(ph);
+    const footer = this.createFooterActions(ph);
+    right.append(promptSection, footer);
+    content.append(dropzone, divider, right);
+
+    const errorHolder = this.createErrorToastShell();
+
+    this.widget.append(content, errorHolder);
+    this.widgetWrap.append(this.widget);
+
+    this.addWidget();
+    return this.workflowCfg.targetCfg.actionMap;
+  }
+
+  popPlaceholders() {
+    return Object.fromEntries(
+      [...this.el.querySelectorAll('[class*="placeholder"]')].map((element) => [
+        element.classList[1]?.replace('icon-', '') || '',
+        element.closest('li')?.innerText || '',
+      ]).filter(([key]) => key),
+    );
+  }
+
+  async loadAspectRatios() {
+    const { origin } = window.location;
+    const baseUrl = (origin.includes('.aem.') || origin.includes('.hlx.'))
+      ? `https://main--unity--adobecom.${origin.includes('.hlx.') ? 'hlx' : 'aem'}.live`
+      : origin;
+    const aspectFile = `${baseUrl}/unity/configs/prompt/aspect-ratio.json`;
+    const results = await fetch(aspectFile);
+    if (!results.ok) throw new Error('Failed to fetch aspect ratios.');
+    const json = await results.json();
+    this.aspectRatios = json?.content?.data;
+  }
+
+  async getAspectRatios(modelId) {
+    if (!this.hasAspectRatioOptions) return [];
+    try {
+      if (!this.aspectRatios || this.aspectRatios.length === 0) await this.loadAspectRatios();
+      const id = modelId || this.selectedModelId;
+      return id
+        ? (this.aspectRatios || []).filter((item) => item.model === id)
+        : (this.aspectRatios || []);
+    } catch (e) {
+      window.lana?.log(`Message: Error loading aspect ratios, Error: ${e}`, this.lanaOptions);
+      return [];
+    }
+  }
+
+  async loadModels() {
+    const { origin } = window.location;
+    const baseUrl = (origin.includes('.aem.') || origin.includes('.hlx.'))
+      ? `https://main--unity--adobecom.${origin.includes('.hlx.') ? 'hlx' : 'aem'}.live`
+      : origin;
+    const modelFile = `${baseUrl}/unity/configs/prompt/model-picker.json`;
+    const results = await fetch(modelFile);
+    if (!results.ok) throw new Error('Failed to fetch models.');
+    const modelJson = await results.json();
+    this.models = modelJson?.content?.data;
+  }
+
+  async getModel() {
+    if (!this.hasModelOptions) return [];
+    try {
+      if (!this.models || this.models.length === 0) await this.loadModels();
+      if (this.models && this.models.length > 0) {
+        const first = this.models[0];
+        this.selectedModelId = first.id || '';
+        this.selectedModelVersion = first.version || '';
+        this.selectedModelText = first.name?.trim() || '';
+      }
+      return this.models;
+    } catch (e) {
+      window.lana?.log(`Message: Error loading models, Error: ${e}`, this.lanaOptions);
+      return [];
+    }
+  }
+
+  createDropzone(ph) {
+    const dropzone = createTag('div', {
+      class: 'ex-pbu-dropzone',
+      role: 'button',
+      tabindex: '0',
+      'aria-label': ph['placeholder-upload-label'] || 'Upload image',
+    });
+
+    const labelRow = createTag('div', { class: 'ex-pbu-dropzone-label' });
+    const labelText = createTag('span', { class: 'ex-pbu-dropzone-label-text' });
+    labelText.textContent = this.el.querySelector('.icon-upload-label')?.closest('li')?.innerText
+      || ph['placeholder-upload-label']
+      || 'Upload image';
+    const infoIcon = createTag('span', { class: 'ex-pbu-info-icon', 'aria-hidden': 'true' }, '<svg><use xlink:href="#unity-info-icon"></use></svg>');
+    labelRow.append(labelText, infoIcon);
+
+    const thumbnail = createTag('div', { class: 'ex-pbu-thumbnail' });
+    const uploadBtn = createTag('button', {
+      class: 'ex-pbu-upload-btn',
+      type: 'button',
+      'aria-label': ph['placeholder-upload-label'] || 'Upload image',
+    }, '<svg><use xlink:href="#unity-upload-icon"></use></svg>');
+
+    const spinner = createTag('div', { class: 'ex-pbu-spinner', 'aria-hidden': 'true' });
+    thumbnail.append(uploadBtn, spinner);
+
+    const fileInput = createTag('input', {
+      type: 'file',
+      id: 'pbu-file-input',
+      accept: 'image/jpeg,image/png,image/webp',
+      class: 'ex-pbu-file-input',
+      'aria-hidden': 'true',
+      tabindex: '-1',
+    });
+
+    const triggerUpload = () => fileInput.click();
+
+    uploadBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      triggerUpload();
+    });
+    dropzone.addEventListener('click', (e) => {
+      if (e.target === uploadBtn || uploadBtn.contains(e.target)) return;
+      triggerUpload();
+    });
+    dropzone.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        triggerUpload();
+      }
+    });
+
+    dropzone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      dropzone.classList.add('drag-over');
+    });
+    dropzone.addEventListener('dragleave', () => dropzone.classList.remove('drag-over'));
+    dropzone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      dropzone.classList.remove('drag-over');
+      const file = e.dataTransfer?.files?.[0];
+      if (file) this.handleFileSelected(file, dropzone);
+    });
+
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files?.[0];
+      if (file) this.handleFileSelected(file, dropzone);
+      fileInput.value = '';
+    });
+
+    dropzone.append(labelRow, thumbnail, fileInput);
+    return dropzone;
+  }
+
+  handleFileSelected(file, dropzone) {
+    const thumbnail = dropzone.querySelector('.ex-pbu-thumbnail');
+    if (!thumbnail) return;
+    thumbnail.classList.add('loading');
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const img = createTag('img', {
+        src: ev.target.result,
+        alt: '',
+        class: 'ex-pbu-preview-img',
+      });
+      img.onload = () => {
+        thumbnail.classList.remove('loading');
+        thumbnail.classList.add('has-image');
+        const existing = thumbnail.querySelector('.ex-pbu-preview-img');
+        if (existing) existing.remove();
+        thumbnail.append(img);
+        const mockAssetId = `local-${Date.now()}`;
+        dropzone.setAttribute('data-asset-id', mockAssetId);
+        this.uploadedImageAssetId = mockAssetId;
+      };
+    };
+    reader.readAsDataURL(file);
+  }
+
+  createPromptSection(ph) {
+    const promptSection = createTag('div', { class: 'ex-pbu-prompt' });
+    const label = createTag('label', {
+      for: 'pbu-prompt-input',
+      class: 'ex-pbu-prompt-label',
+    });
+    label.textContent = ph['placeholder-prompt'] || 'Prompt';
+
+    const textarea = createTag('textarea', {
+      id: 'pbu-prompt-input',
+      class: 'inp-field',
+      placeholder: ph['placeholder-input'] || '',
+      'aria-label': ph['placeholder-prompt'] || 'Prompt',
+      rows: '3',
+    });
+
+    promptSection.append(label, textarea);
+    return promptSection;
+  }
+
+  createFooterActions(ph) {
+    const footer = createTag('div', { class: 'ex-pbu-footer' });
+    const footerLeft = createTag('div', { class: 'ex-pbu-footer-left' });
+    const footerRight = createTag('div', { class: 'ex-pbu-footer-right' });
+
+    if (this.hasModelOptions) {
+      const modelContainer = createTag('div', { class: 'models-container', 'aria-label': 'Model options' });
+      const modelItems = this.modelDropdown();
+      if (modelItems.length > 0) modelContainer.append(...modelItems);
+      footerLeft.append(modelContainer);
+    }
+
+    if (this.hasAspectRatioOptions) {
+      const aspectContainer = createTag('div', { class: 'verbs-container', 'aria-label': 'Aspect ratio options', 'data-aspect-container': 'true' });
+      const aspectItems = this.aspectRatioDropdown();
+      if (aspectItems.length > 0) aspectContainer.append(...aspectItems);
+      footerLeft.append(aspectContainer);
+    }
+
+    const moreBtn = this.createMoreBtn(ph);
+    const genBtnEl = this.createActBtn(this.el.querySelector('.icon-generate')?.closest('li'), 'gen-btn');
+
+    footerRight.append(moreBtn, genBtnEl);
+    footer.append(footerLeft, footerRight);
+    return footer;
+  }
+
+  modelDropdown() {
+    if (!this.hasModelOptions || !this.models || this.models.length === 0) return [];
+    const { models } = this;
+    const [first] = models;
+    const nameContainer = createTag('span', { class: 'model-name' }, first.name?.trim() || '');
+    const selectedElement = createTag('button', {
+      class: 'selected-model',
+      'aria-expanded': 'false',
+      'aria-controls': 'pbu-model-menu',
+      'aria-label': 'model type',
+      'aria-haspopup': 'listbox',
+      role: 'combobox',
+      'aria-labelledby': 'listbox-label',
+      'data-selected-model-id': first.id || '',
+      'data-selected-model-version': first.version || '',
+    });
+    if (first.icon) selectedElement.append(createTag('img', { src: first.icon, alt: '' }));
+    selectedElement.append(nameContainer);
+    this.selectedModelId = first.id || '';
+    this.selectedModelVersion = first.version || '';
+    this.selectedModelText = first.name?.trim() || '';
+    this.widgetWrap.setAttribute('data-selected-model-id', this.selectedModelId);
+    this.widgetWrap.setAttribute('data-selected-model-version', this.selectedModelVersion);
+
+    const menuIcon = createTag('span', { class: 'menu-icon' }, '<svg><use xlink:href="#unity-chevron-icon"></use></svg>');
+    selectedElement.append(menuIcon);
+
+    if (models.length <= 1) {
+      selectedElement.setAttribute('disabled', 'true');
+      return [selectedElement];
+    }
+
+    const listItems = createTag('ul', {
+      class: 'verb-list',
+      id: 'pbu-model-menu',
+      role: 'listbox',
+      'aria-labelledby': 'listbox-label',
+      style: 'display: none;',
+    });
+
+    this.buildDropdownItems(models, listItems, selectedElement, menuIcon, false);
+
+    const handleDocumentClick = (e) => {
+      const menuContainer = selectedElement.parentElement;
+      if (!menuContainer?.contains(e.target)) {
+        document.removeEventListener('click', handleDocumentClick);
+        this.closeVerbOrModelMenu(selectedElement);
+      }
+    };
+
+    selectedElement.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.hideAllMenus(selectedElement);
+      this.showVerbMenu(selectedElement);
+      document.addEventListener('click', handleDocumentClick);
+    }, true);
+
+    selectedElement.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        this.hideAllMenus(selectedElement);
+        this.showVerbMenu(selectedElement);
+      }
+      if (e.key === 'Escape') {
+        this.closeVerbOrModelMenu(selectedElement);
+        selectedElement.focus();
+      }
+    });
+
+    return [selectedElement, listItems];
+  }
+
+  aspectRatioDropdown() {
+    if (!this.hasAspectRatioOptions) return [];
+    const ratios = (this.aspectRatios || []).filter((item) => !this.selectedModelId || item.model === this.selectedModelId);
+    if (ratios.length === 0) return [];
+
+    const first = ratios[0];
+    this.selectedAspectRatio = first.id || '';
+    this.selectedAspectRatioLabel = first.label || first.id || '';
+    this.widgetWrap?.setAttribute('data-selected-aspect-ratio', this.selectedAspectRatio);
+
+    const selectedElement = createTag('button', {
+      class: 'selected-verb',
+      'aria-expanded': 'false',
+      'aria-controls': 'pbu-aspect-menu',
+      'aria-label': 'aspect ratio',
+      'aria-haspopup': 'listbox',
+      role: 'combobox',
+      'data-selected-aspect': this.selectedAspectRatio,
+    });
+    if (first.icon) selectedElement.append(createTag('img', { src: first.icon, alt: '' }));
+    selectedElement.append(document.createTextNode(this.selectedAspectRatioLabel));
+
+    const menuIcon = createTag('span', { class: 'menu-icon' }, '<svg><use xlink:href="#unity-chevron-icon"></use></svg>');
+    selectedElement.append(menuIcon);
+
+    if (ratios.length <= 1) {
+      selectedElement.setAttribute('disabled', 'true');
+      return [selectedElement];
+    }
+
+    const listItems = createTag('ul', {
+      class: 'verb-list',
+      id: 'pbu-aspect-menu',
+      role: 'listbox',
+      'aria-labelledby': 'listbox-label',
+      style: 'display: none;',
+    });
+
+    this.buildDropdownItems(ratios, listItems, selectedElement, menuIcon, true);
+
+    const handleDocumentClick = (e) => {
+      const menuContainer = selectedElement.parentElement;
+      if (!menuContainer?.contains(e.target)) {
+        document.removeEventListener('click', handleDocumentClick);
+        this.closeVerbOrModelMenu(selectedElement);
+      }
+    };
+
+    selectedElement.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.hideAllMenus(selectedElement);
+      this.showVerbMenu(selectedElement);
+      document.addEventListener('click', handleDocumentClick);
+    }, true);
+
+    selectedElement.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        this.hideAllMenus(selectedElement);
+        this.showVerbMenu(selectedElement);
+      }
+      if (e.key === 'Escape') {
+        this.closeVerbOrModelMenu(selectedElement);
+        selectedElement.focus();
+      }
+    });
+
+    return [selectedElement, listItems];
+  }
+
+  buildDropdownItems(items, listContainer, selectedElement, menuIcon, isAspect) {
+    const fragment = document.createDocumentFragment();
+    items.forEach((item, idx) => {
+      const listItem = createTag('li', { class: 'verb-item', role: 'presentation' });
+      const selectedIcon = createTag('span', { class: 'selected-icon' }, '<svg><use xlink:href="#unity-checkmark-icon"></use></svg>');
+      const link = createTag('a', {
+        href: '#',
+        class: isAspect ? 'verb-link' : 'verb-link model-link',
+        'data-id': item.id || '',
+        ...(isAspect
+          ? { 'data-aspect-label': item.label || item.id || '' }
+          : {
+            'data-model-id': item.id || '',
+            'data-model-version': item.version || '',
+          }),
+        'aria-selected': idx === 0 ? 'true' : 'false',
+        role: 'option',
+      });
+      if (item.icon) link.append(createTag('img', { loading: 'lazy', src: item.icon, alt: '' }));
+      const labelText = isAspect ? (item.label || item.id || '') : (item.name?.trim() || '');
+      if (!isAspect) {
+        link.append(createTag('span', { class: 'model-name' }, labelText));
+      } else {
+        link.append(document.createTextNode(labelText));
+      }
+      if (idx === 0) listItem.classList.add('selected');
+      link.prepend(selectedIcon);
+      listItem.append(link);
+      fragment.append(listItem);
+    });
+    listContainer.append(fragment);
+
+    listContainer.addEventListener('click', (e) => {
+      const link = e.target.closest('.verb-link');
+      if (!link) return;
+      this.handleDropdownItemClick(link, listContainer, selectedElement, menuIcon, isAspect)(e);
+    });
+  }
+
+  handleDropdownItemClick(link, container, selectedElement, menuIcon, isAspect) {
+    return (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      container.querySelectorAll('.verb-link').forEach((l) => {
+        l.parentElement.classList.remove('selected');
+        l.setAttribute('aria-selected', 'false');
+      });
+      link.parentElement.classList.add('selected');
+      link.setAttribute('aria-selected', 'true');
+      this.closeVerbOrModelMenu(selectedElement);
+
+      if (isAspect) {
+        this.selectedAspectRatio = link.getAttribute('data-id') || '';
+        this.selectedAspectRatioLabel = link.getAttribute('data-aspect-label') || this.selectedAspectRatio;
+        selectedElement.setAttribute('data-selected-aspect', this.selectedAspectRatio);
+        const copiedNodes = [];
+        const imgEl = link.querySelector('img');
+        if (imgEl) copiedNodes.push(imgEl.cloneNode(true));
+        copiedNodes.push(document.createTextNode(this.selectedAspectRatioLabel));
+        selectedElement.replaceChildren(...copiedNodes, menuIcon);
+        this.widgetWrap?.setAttribute('data-selected-aspect-ratio', this.selectedAspectRatio);
+      } else {
+        const newModelId = link.getAttribute('data-model-id') || '';
+        const newModelVersion = link.getAttribute('data-model-version') || '';
+        const newModelName = link.querySelector('.model-name')?.textContent?.trim() || '';
+        this.selectedModelId = newModelId;
+        this.selectedModelVersion = newModelVersion;
+        this.selectedModelText = newModelName;
+        selectedElement.setAttribute('data-selected-model-id', newModelId);
+        selectedElement.setAttribute('data-selected-model-version', newModelVersion);
+        const imgEl = link.querySelector('img');
+        const newNodes = [];
+        if (imgEl) newNodes.push(imgEl.cloneNode(true));
+        newNodes.push(createTag('span', { class: 'model-name' }, newModelName));
+        selectedElement.replaceChildren(...newNodes, menuIcon);
+        this.widgetWrap?.setAttribute('data-selected-model-id', newModelId);
+        this.widgetWrap?.setAttribute('data-selected-model-version', newModelVersion);
+        this.updateAspectRatioDropdown();
+      }
+      selectedElement.focus();
+    };
+  }
+
+  updateAspectRatioDropdown() {
+    if (!this.widgetWrap) return;
+    const aspectContainer = this.widgetWrap.querySelector('[data-aspect-container="true"]');
+    if (!aspectContainer) return;
+    const newItems = this.aspectRatioDropdown();
+    aspectContainer.replaceChildren(...newItems);
+  }
+
+  showVerbMenu(selectedElement) {
+    const menuContainer = selectedElement.parentElement;
+    this.widgetWrap?.querySelectorAll('.verbs-container, .models-container').forEach((container) => {
+      if (container !== menuContainer) {
+        container.classList.remove('show-menu');
+        container.querySelector('.selected-verb, .selected-model')?.setAttribute('aria-expanded', 'false');
+      }
+    });
+    menuContainer.classList.toggle('show-menu');
+    selectedElement.setAttribute('aria-expanded', menuContainer.classList.contains('show-menu') ? 'true' : 'false');
+    if (selectedElement.nextElementSibling?.hasAttribute('style')) {
+      selectedElement.nextElementSibling.removeAttribute('style');
+    }
+  }
+
+  closeVerbOrModelMenu(selectedElement) {
+    const menuContainer = selectedElement.parentElement;
+    if (!menuContainer) return;
+    menuContainer.classList.remove('show-menu');
+    selectedElement.setAttribute('aria-expanded', 'false');
+  }
+
+  hideAllMenus(exceptEl) {
+    if (!this.widgetWrap) return;
+    this.widgetWrap.querySelectorAll('.verbs-container, .models-container').forEach((container) => {
+      const btn = container.querySelector('.selected-verb, .selected-model');
+      if (btn && btn !== exceptEl) {
+        container.classList.remove('show-menu');
+        btn.setAttribute('aria-expanded', 'false');
+      }
+    });
+  }
+
+  createMoreBtn(ph) {
+    const moreLi = this.el.querySelector('.icon-more')?.closest('li');
+    const moreUrl = moreLi?.querySelector('a')?.href || 'https://firefly.adobe.com';
+    const moreText = moreLi?.querySelector('a')?.innerText?.trim()
+      || moreLi?.innerText?.trim()
+      || ph['placeholder-more']
+      || 'More';
+    const btn = createTag('a', {
+      href: moreUrl,
+      class: 'unity-act-btn ex-pbu-more-btn',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    });
+    btn.textContent = moreText;
+    return btn;
+  }
+
+  createActBtn(cfg, cls) {
+    if (!cfg) return createTag('a', { href: '#', class: `unity-act-btn ${cls}` });
+    const txt = cfg.innerText?.trim();
+    const img = cfg.querySelector('img[src*=".svg"]');
+    const btn = createTag('a', {
+      href: '#',
+      class: `unity-act-btn ${cls}`,
+      'daa-ll': 'Generate',
+      'aria-label': txt?.split('\n')[0] || 'Generate',
+    });
+    if (img) btn.append(createTag('div', { class: 'btn-ico' }, img));
+    if (txt) btn.append(createTag('div', { class: 'btn-txt' }, txt.split('\n')[0]));
+    this.genBtn = btn;
+    return btn;
+  }
+
+  addWidget() {
+    const interactArea = this.target.querySelector('.copy');
+    const para = interactArea?.querySelector(this.workflowCfg.targetCfg.target);
+    this.widgetWrap.append(this.widget);
+    if (para && this.workflowCfg.targetCfg.insert === 'before') para.before(this.widgetWrap);
+    else if (para) para.after(this.widgetWrap);
+    else interactArea?.appendChild(this.widgetWrap);
+  }
+
+  createErrorToastShell() {
+    const errorHolder = createTag('div', { class: 'ex-pbu-error-holder' });
+    const alertImg = createTag('img', { loading: 'lazy', src: `${getUnityLibs()}/img/icons/alert.svg` });
+    const closeImg = createTag('img', { loading: 'lazy', src: `${getUnityLibs()}/img/icons/close.svg` });
+    const alertText = createTag('div', { class: 'alert-text' }, createTag('p', {}, ''));
+    const alertIcon = createTag('div', { class: 'alert-icon' });
+    alertIcon.append(alertImg, alertText);
+    const alertClose = createTag('a', { class: 'alert-close', href: '#' });
+    alertClose.append(closeImg, createTag('span', { class: 'alert-close-text' }, 'Close error toast'));
+    const alertContent = createTag('div', { class: 'alert-content' });
+    alertContent.append(alertIcon, alertClose);
+    const alertToast = createTag('div', { class: 'alert-toast' }, alertContent);
+    errorHolder.append(alertToast);
+
+    const closeToast = (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.hideErrorToast();
+    };
+    alertClose.addEventListener('click', closeToast);
+    alertClose.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') closeToast(e);
+    });
+
+    return errorHolder;
+  }
+
+  showErrorToast(errorType, err) {
+    if (!this.widget) return;
+    const errorHolder = this.widget.querySelector('.ex-pbu-error-holder');
+    if (!errorHolder) return;
+    const lang = document.querySelector('html').getAttribute('lang');
+    const msgEl = lang !== 'ja-JP'
+      ? this.el.querySelector(errorType)?.nextSibling
+      : this.el.querySelector(errorType)?.parentElement;
+    const msg = msgEl?.textContent || '';
+    const alertText = errorHolder.querySelector('.alert-text p');
+    if (alertText) alertText.textContent = msg;
+    errorHolder.classList.add('show');
+    if (err) window.lana?.log(`Message: ${msg}, Error: ${err}`, this.lanaOptions);
+  }
+
+  hideErrorToast() {
+    if (!this.widget) return;
+    const errorHolder = this.widget.querySelector('.ex-pbu-error-holder');
+    errorHolder?.classList.remove('show');
+  }
+}

--- a/unitylibs/core/workflow/workflow-firefly/action-binder.js
+++ b/unitylibs/core/workflow/workflow-firefly/action-binder.js
@@ -230,6 +230,11 @@ export default class ActionBinder {
 
   getSelectedModelVersion = () => this.widgetWrap.getAttribute('data-selected-model-version');
 
+  getSelectedAspectRatio = () => this.widgetWrap?.getAttribute('data-selected-aspect-ratio');
+
+  getUploadedImageAssetId = () => this.block?.querySelector('.ex-pbu-dropzone[data-asset-id]')
+    ?.getAttribute('data-asset-id') || null;
+
   getSelectedModelDisplayName = () => this.widgetWrap.getAttribute('data-selected-model-name')
     || this.block.querySelector('.models-container .selected-model .model-name')?.textContent?.trim()
     || '';
@@ -330,6 +335,8 @@ export default class ActionBinder {
     try {
       const modelId = this.getSelectedModelId();
       const modelVersion = this.getSelectedModelVersion();
+      const aspectRatio = this.getSelectedAspectRatio();
+      const uploadedImageId = this.getUploadedImageAssetId();
       const payload = {
         targetProduct: this.workflowCfg.productName,
         additionalQueryParams: queryParams,
@@ -339,6 +346,8 @@ export default class ActionBinder {
           ...(modelId ? { modelId } : {}),
           ...(modelVersion ? { modelVersion } : {}),
           ...(stylePayload ? { style: stylePayload } : {}),
+          ...(aspectRatio ? { aspectRatio } : {}),
+          ...(uploadedImageId ? { referenceImageId: uploadedImageId } : {}),
           locale: getLocale(),
           action,
         },

--- a/unitylibs/core/workflow/workflow.js
+++ b/unitylibs/core/workflow/workflow.js
@@ -34,6 +34,10 @@ class WfInitiator {
         `${widgetBase}/prompt-bar-style/prompt-bar-style.js`,
         `${widgetBase}/prompt-bar-style/prompt-bar-style.css`,
       ],
+      'prompt-bar-upload': [
+        `${widgetBase}/prompt-bar-upload/prompt-bar-upload.js`,
+        `${widgetBase}/prompt-bar-upload/prompt-bar-upload.css`,
+      ],
     };
   }
 


### PR DESCRIPTION
## Summary
Adds a new `prompt-bar-upload` Unity widget for the Image-to-Video Firefly feature page. The widget provides an image dropzone with upload/spinner/preview states, a prompt textarea, model and aspect-ratio dropdowns (aspect ratios keyed per model from a spreadsheet config), a "More" filters button, and a "Generate" CTA that passes all inputs to the connector backend.

## Changes
- `unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.js` — New widget class (dropzone, prompt, model/aspect dropdowns, error toast overlay, generate flow)
- `unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.css` — Dark-themed styles with `ex-pbu-*` class prefix, responsive mobile layout
- `unitylibs/core/workflow/workflow.js` — Registered `prompt-bar-upload` in `getWidgetRegistry()`
- `unitylibs/core/workflow/workflow-firefly/action-binder.js` — Added `getSelectedAspectRatio()` and `getUploadedImageAssetId()` getters; extended `generateContent()` payload with `aspectRatio` and `referenceImageId`
- `test/core/workflow/mocks/ff-upload-body.html` — HTML fixture for unit tests
- `test/core/workflow/prompt-bar-upload.test.js` — 42 unit tests; full suite 770 passed, 0 failed

## Testing
Full test suite run: 770 tests passed, 0 failed, 3 skipped. Coverage includes widget initialization, DOM structure, slot parsing, model/aspect dropdowns, file upload wiring, drag-and-drop, spinner/preview states, error toast show/hide, and actionMap return value.

Jira: MWPW-192852