### PR TITLE
fix(MWPW-190279): locale-aware line-break rules for DE, BR, RO, JP in prompt-bar

### DIFF
--- a/unitylibs/core/widgets/prompt-bar/prompt-bar.css
+++ b/unitylibs/core/widgets/prompt-bar/prompt-bar.css
@@ -1311,3 +1311,65 @@
     padding: 0px;
   }
 }
+
+/* =============================================================================
+   LOC LINE-BREAK FIX — MWPW-190279
+   Prevents text overflow and incorrect line-breaking in the prompt bar widget
+   for locales with long compound words (DE, BR, RO) and CJK scripts (JA).
+   Applies to: hero-marquee and upload-marquee Unity blocks.
+   ============================================================================= */
+
+/* Base rule: safe word-wrap for all locales on headings and body text
+   within unity-enabled marquee blocks. Prevents long translated strings
+   from overflowing fixed-width containers. */
+.hero-marquee.unity-enabled .interactive-area .text h1,
+.hero-marquee.unity-enabled .interactive-area .text h2,
+.hero-marquee.unity-enabled .interactive-area .text h3,
+.hero-marquee.unity-enabled .interactive-area .text h4,
+.hero-marquee.unity-enabled .interactive-area .text h5,
+.hero-marquee.unity-enabled .interactive-area .text p,
+.upload-marquee.unity-enabled .interactive-area .text h1,
+.upload-marquee.unity-enabled .interactive-area .text h2,
+.upload-marquee.unity-enabled .interactive-area .text h3,
+.upload-marquee.unity-enabled .interactive-area .text h4,
+.upload-marquee.unity-enabled .interactive-area .text h5,
+.upload-marquee.unity-enabled .interactive-area .text p {
+  overflow-wrap: break-word;
+  word-break: break-word;
+  hyphens: auto;
+}
+
+/* Prompt input field: allow safe breaking so long pasted or typed strings
+   in localized contexts do not overflow the autocomplete container. */
+.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .inp-wrap .inp-field {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+/* Japanese: use keep-all + strict line-break to follow JIS line-breaking rules.
+   Overrides break-word which can incorrectly split CJK characters mid-word.
+   overflow-wrap: anywhere is used instead to handle edge-case long strings
+   (e.g. URLs or user-typed latin text in a JA context). */
+[lang="ja-JP"] .hero-marquee.unity-enabled .interactive-area .text h1,
+[lang="ja-JP"] .hero-marquee.unity-enabled .interactive-area .text h2,
+[lang="ja-JP"] .hero-marquee.unity-enabled .interactive-area .text h3,
+[lang="ja-JP"] .hero-marquee.unity-enabled .interactive-area .text h4,
+[lang="ja-JP"] .hero-marquee.unity-enabled .interactive-area .text h5,
+[lang="ja-JP"] .hero-marquee.unity-enabled .interactive-area .text p,
+[lang="ja-JP"] .upload-marquee.unity-enabled .interactive-area .text h1,
+[lang="ja-JP"] .upload-marquee.unity-enabled .interactive-area .text h2,
+[lang="ja-JP"] .upload-marquee.unity-enabled .interactive-area .text h3,
+[lang="ja-JP"] .upload-marquee.unity-enabled .interactive-area .text h4,
+[lang="ja-JP"] .upload-marquee.unity-enabled .interactive-area .text h5,
+[lang="ja-JP"] .upload-marquee.unity-enabled .interactive-area .text p {
+  word-break: keep-all;
+  line-break: strict;
+  overflow-wrap: anywhere;
+  hyphens: none;
+}
+
+[lang="ja-JP"] .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .inp-wrap .inp-field {
+  word-break: keep-all;
+  line-break: strict;
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Summary

Fixes MWPW-190279 — line breaking issues visible in the prompt-based Unity block on localized pages (de-DE, pt-BR, ro-RO, ja-JP).

Although the affected pages have since been migrated to the new upload marquee experience, the underlying block had no locale-aware line-breaking rules. This fix makes the block robust for future use across both `hero-marquee` and `upload-marquee` contexts.

## Root Cause

The `.inp-wrap .inp-field` textarea and heading/body text elements in unity-enabled marquee blocks had no `overflow-wrap`, `word-break`, or locale-aware line-breaking rules. Languages like German and Romanian produce long compound words that overflow fixed-width containers without these guards. Japanese requires CJK-specific line-breaking rules (`word-break: keep-all`, `line-break: strict`) that differ from the Latin-script approach.

## Changes

**File:** `unitylibs/core/widgets/prompt-bar/prompt-bar.css`

**Base rule (all locales):**
- Adds `overflow-wrap: break-word`, `word-break: break-word`, and `hyphens: auto` to heading and body text elements inside `.hero-marquee.unity-enabled` and `.upload-marquee.unity-enabled` interactive areas
- Adds `overflow-wrap: break-word` and `word-break: break-word` to `.inp-wrap .inp-field` (the prompt textarea)

**Japanese override (`[lang="ja-JP"]`):**
- Applies `word-break: keep-all` and `line-break: strict` to follow JIS line-breaking rules
- Uses `overflow-wrap: anywhere` (instead of `break-word`) to handle edge cases like Latin strings or URLs typed into a JA context
- Clears `hyphens: auto` (not applicable to CJK)
- Applies to both heading/body text and the `.inp-field` prompt input

This follows the existing `[lang="ja-JP"]` locale override pattern already present in this file.

## Testing

- [ ] Verify heading text wraps correctly on de-DE, pt-BR, ro-RO locales (no overflow)
- [ ] Verify Japanese heading text respects JIS line-breaking (no mid-character breaks)
- [ ] Verify prompt input field handles long localized strings without overflow
- [ ] Verify no visual regression on en-US baseline

## Jira

[MWPW-190279](https://jira.corp.adobe.com/browse/MWPW-190279)