### PR TITLE
fix(MWPW-190444): remove 512x512 minimum dimension restriction from Firefly upload config

### DIFF
--- a/unitylibs/core/workflow/workflow-upload/target-config.json
+++ b/unitylibs/core/workflow/workflow-upload/target-config.json
@@ -24,9 +24,7 @@
     },
     "limits-firefly": {
       "allowedFileTypes": ["image/jpeg", "image/png", "image/jpg", "image/webp"],
-      "maxFileSize": 100000000,
-      "minHeight": 512,
-      "minWidth": 512
+      "maxFileSize": 100000000
     },
     "showSplashScreen": true,
     "splashScreenConfig": {


### PR DESCRIPTION
## Summary

Fixes MWPW-190444 — removes the 512×512 minimum image dimension restriction from Firefly upload flows.

The 512×512 minimum was a product-specified requirement that has since been lifted. The restriction was enforced on the primary upload path but was never applied to the Edit flow (reference image upload from device), causing an inconsistency. Removing the config entries resolves both issues simultaneously: the primary upload no longer blocks small images, and the Edit flow inconsistency is moot.

## Root Cause

The 512×512 minimum dimension was hardcoded in `target-config.json` under `limits-firefly` as `minHeight: 512` and `minWidth: 512`. This config is merged into `this.limits` in `action-binder.js` at construction time and evaluated in `checkImageDimensions()`. Because `isMinLimits` is only truthy when both `minWidth` and `minHeight` are present, removing these keys from the config causes the minimum-dimension check block to become a no-op with no JS changes required.

The Edit flow (reference image upload via the prompt-bar widget) bypassed `uploadImage()` entirely and therefore never called `checkImageDimensions()`, which is why the inconsistency existed. Both paths now behave identically: no minimum dimension is enforced.

## Changes

**File:** `unitylibs/core/workflow/workflow-upload/target-config.json`

- Removed `minHeight: 512` from `limits-firefly`
- Removed `minWidth: 512` from `limits-firefly`
- All other limits (`maxFileSize`, `allowedFileTypes`) are unchanged
- Photoshop and Lightroom limits (`limits-photoshop`, `limits-lightroom`) are completely unaffected

No JavaScript changes are required.

## Verification

- Confirmed `minHeight`/`minWidth` only exist in `target-config.json` in this repo (no other JS files hardcode these values)
- Confirmed `fallback.js` reference to `minHeight` is a CSS property on a browser-compatibility banner — unrelated
- Confirmed no API endpoint dynamically supplies dimension limits — this config is the single source of truth

## Testing

- [ ] Verify images smaller than 512×512 can be uploaded via the main upload flow on Firefly/Doodlebug pages
- [ ] Verify images smaller than 512×512 can be uploaded via the Edit flow (reference image from device)
- [ ] Verify images above `maxFileSize` (100MB) are still correctly rejected on both paths
- [ ] Verify allowed file types (JPEG, PNG, WEBP) validation is still enforced
- [ ] Verify Photoshop and Lightroom upload validation is unaffected

## Jira

[MWPW-190444](https://jira.corp.adobe.com/browse/MWPW-190444)