### PR TITLE
[MWPW-193716,MWPW-194279,MWPW-194149] : fixing dropdown position

### DIFF
--- a/unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.css
+++ b/unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.css
@@ -92,6 +92,8 @@ min-width: 0;
 .unity-prompt-bar-upload.unity-enabled .pbu-right-section .pbu-prompt-bar-container {
 display: flex;
 flex-direction: column;
+align-items: stretch;
+align-content: stretch;
 gap: 0;
 width: 100%;
 min-width: 0;
@@ -131,9 +133,18 @@ max-width: 100%;
 
 .unity-prompt-bar-upload.unity-enabled .pbu-right-section .unity-slf-prompt-label {
 margin-bottom: 0px;
+margin-inline: 0;
 padding: 0;
+padding-inline: 0;
+-webkit-padding-start: 0;
+-webkit-padding-end: 0;
 display: block;
 flex-shrink: 0;
+align-self: stretch;
+width: 100%;
+max-width: 100%;
+box-sizing: border-box;
+text-align: start;
 }
 
 .unity-prompt-bar-upload.unity-enabled .pbu-right-section .inp-field {
@@ -141,14 +152,56 @@ flex: 1;
 min-height: 80px;
 resize: none;
 width: 100%;
+max-width: 100%;
+align-self: stretch;
 box-sizing: border-box;
-padding-bottom: 10px;
+padding: 0;
+padding-inline: 0;
+padding-block: 0 10px;
+-webkit-padding-start: 0;
+-webkit-padding-end: 0;
 margin: 0 0 12px 0;
+margin-inline: 0;
 border: none;
 background: transparent;
 outline: none;
 font-size: var(--type-body-s-size, 15px);
 line-height: 1.45;
+text-align: start;
+-webkit-appearance: none;
+appearance: none;
+scrollbar-width: thin;
+scrollbar-color: #888 transparent;
+}
+
+.unity-prompt-bar-upload.unity-enabled .pbu-right-section .inp-field::-webkit-scrollbar {
+width: 6px;
+height: 6px;
+}
+
+.unity-prompt-bar-upload.unity-enabled .pbu-right-section .inp-field::-webkit-scrollbar-track {
+background: transparent;
+}
+
+.unity-prompt-bar-upload.unity-enabled .pbu-right-section .inp-field::-webkit-scrollbar-thumb {
+background-color: #888;
+border-radius: 6px;
+}
+
+.unity-prompt-bar-upload.unity-enabled .pbu-right-section .inp-field::-webkit-scrollbar-thumb:hover {
+background-color: #a0a0a0;
+}
+
+.unity-prompt-bar-upload.unity-enabled .interactive-area.light .pbu-right-section .inp-field {
+scrollbar-color: #6a6a6a rgb(0 0 0 / 12%);
+}
+
+.unity-prompt-bar-upload.unity-enabled .interactive-area.light .pbu-right-section .inp-field::-webkit-scrollbar-thumb {
+background-color: #6a6a6a;
+}
+
+.unity-prompt-bar-upload.unity-enabled .interactive-area.light .pbu-right-section .inp-field::-webkit-scrollbar-thumb:hover {
+background-color: #555;
 }
 
 .unity-prompt-bar-upload.unity-enabled .pbu-controls-footer {
@@ -196,6 +249,12 @@ line-height: 18px;
 .unity-prompt-bar-upload.unity-enabled .unity-slf-prompt-label {
 display: block;
 margin-bottom: 8px;
+margin-inline: 0;
+padding-inline: 0;
+text-align: start;
+width: 100%;
+max-width: 100%;
+box-sizing: border-box;
 }
 
 .unity-prompt-bar-upload.unity-enabled .interactive-area.dark .inp-field,

--- a/unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.css
+++ b/unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.css
@@ -590,12 +590,19 @@ font-weight: 400;
 
 .unity-prompt-bar-upload.unity-enabled .pbu-controls-footer .models-container .verb-list,
 .unity-prompt-bar-upload.unity-enabled .pbu-controls-footer .verbs-container .verb-list {
-top: auto;
-bottom: 100%;
+top: 100%;
+bottom: auto;
+left: 0;
 transform: none;
 animation: none;
-margin-bottom: 4px;
-z-index: 10;
+margin-top: 4px;
+margin-bottom: 0;
+}
+
+[dir="rtl"] .unity-prompt-bar-upload.unity-enabled .pbu-controls-footer .models-container .verb-list,
+[dir="rtl"] .unity-prompt-bar-upload.unity-enabled .pbu-controls-footer .verbs-container .verb-list {
+left: auto;
+right: 0;
 }
 
 .unity-prompt-bar-upload.unity-enabled .pbu-controls-footer .models-container,
@@ -604,9 +611,9 @@ position: relative;
 z-index: 1;
 }
 
-.unity-prompt-bar-upload.unity-enabled .pbu-controls-footer .models-container.show-menu,
-.unity-prompt-bar-upload.unity-enabled .pbu-controls-footer .verbs-container.show-menu {
-z-index: 300;
+.unity-prompt-bar-upload.unity-enabled .pbu-controls-footer .models-container.show-menu .verb-list,
+.unity-prompt-bar-upload.unity-enabled .pbu-controls-footer .verbs-container.show-menu .verb-list {
+animation: none;
 }
 
 .pbu-drop-zone-wrap {

--- a/unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.js
+++ b/unitylibs/core/widgets/prompt-bar-upload/prompt-bar-upload.js
@@ -31,7 +31,6 @@ function svgIcon(href) {
   return `<svg><use xlink:href="${href}"></use></svg>`;
 }
 
-/** Landscape / square ratios use horizontal frame; portrait uses vertical frame. */
 function getAspectRatioIconHref(ratio) {
   const parts = String(ratio).split(':').map((s) => parseFloat(String(s).trim(), 10));
   if (parts.length !== 2 || Number.isNaN(parts[0]) || Number.isNaN(parts[1]) || parts[1] === 0) {


### PR DESCRIPTION
Resolves: [MWPW-193716](https://jira.corp.adobe.com/browse/MWPW-193716)
[MWPW-194279](https://jira.corp.adobe.com/browse/MWPW-194279)
[MWPW-194149](https://jira.corp.adobe.com/browse/MWPW-194149)

Note: With this PR the dropdown opens on the bottom. But it gets cut. For that the fix is in cc repo. Below pr needs to be merged to cc stage to fully test this. 

https://github.com/adobecom/da-cc/pull/49

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/firefly/features/image-to-video?unitylibs=MWPW-193716
- After: https://main--da-cc--adobecom.aem.page/products/firefly/features/image-to-video?unitylibs=MWPW-193716