### PR TITLE
MWPW-194184: Fix cancel on 2nd Generate redirecting to Firefly instead of a.com

### DIFF
--- a/test/core/workflow/workflow.firefly.test.js
+++ b/test/core/workflow/workflow.firefly.test.js
@@ -1194,7 +1194,7 @@ describe('Firefly Workflow Tests', () => {
     let event;
 
     beforeEach(() => {
-      testWidget = new UnityWidget(block, unityElement, workflowCfg, spriteContainer);
+      testWidget = new UnityWidget(block, unityElement, { ...workflowCfg, targetCfg: { ...workflowCfg.targetCfg } }, spriteContainer);
       testWidget.widgetWrap = document.createElement('div');
       testWidget.widget = document.createElement('div');
       testWidget.updateDropdownForVerb = sinon.stub();

--- a/unitylibs/core/workflow/workflow-prompt-bar-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-prompt-bar-upload/action-binder.js
@@ -108,7 +108,6 @@ export default class ActionBinder {
     this.limits = workflowCfg.targetCfg?.limits || {};
     const productTag = workflowCfg.targetCfg?.[`productTag-${workflowCfg.productName?.toLowerCase()}`] || 'FF';
     this.lanaOptions = { sampleRate: 1, tags: `Unity-${productTag}-PBU` };
-    
   }
 
   getApiConfig() {
@@ -413,7 +412,6 @@ export default class ActionBinder {
     await this.continueInApp(query, selectedModelId, selectedAspectRatio);
   }
 
-
   async continueInApp(query, modelId, aspectRatio) {
     const { getCgenQueryParams } = await import(`${getUnityLibs()}/utils/cgen-utils.js`);
     const queryParams = getCgenQueryParams(this.unityEl);
@@ -499,6 +497,7 @@ export default class ActionBinder {
       this.uploadAbortController = null;
       sendAnalyticsEvent(new CustomEvent('Cancel|UnityWidget'));
       this.logAnalytics('Cancel|UnityWidget', { assetId: this.assetId });
+      this.assetId = null;
       await this.ensureTransitionScreen();
       await this.transitionScreen.showSplashScreen();
       const e = new Error('Operation termination requested.');

--- a/unitylibs/core/workflow/workflow-prompt-bar-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-prompt-bar-upload/action-binder.js
@@ -301,6 +301,7 @@ export default class ActionBinder {
         this.apiConfig.endPoint.assetUpload,
         { body: JSON.stringify(assetDetails) },
       );
+      if (signal.aborted) return false;
       const { id, href, blocksize, uploadUrls } = resJson;
       this.assetId = id;
       this.logAnalytics('Asset Created|UnityWidget', { assetId: this.assetId });
@@ -459,6 +460,7 @@ export default class ActionBinder {
           return response.json();
         },
       );
+      if (this.promiseStack.length > 0) return;
       this.logAnalytics('Generate Complete|UnityWidget', { assetId: this.assetId });
       this.LOADER_LIMIT = 100;
       if (this.transitionScreen?.splashScreenEl) {


### PR DESCRIPTION
- Reset assetId in cancelUploadOperation so subsequent Generate calls re-upload the asset with proper AbortController support rather than skipping to continueInApp with a stale assetId and no cancellation hook.

Resolves: [MWPW-194184](https://jira.corp.adobe.com/browse/MWPW-194184)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/firefly/features/ai-video-generator?unitylibs=stage
- After: https://main--da-cc--adobecom.aem.page/products/firefly/features/ai-video-generator?unitylibs=MWPW-194184
