### PR TITLE
[MWPW-193816] skip file dimension check if not able to get width/height of image

### DIFF
--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -401,10 +401,7 @@ export default class ActionBinder {
     let { width, height } = {};
     try {
       ({ width, height } = await getImageDimensions(file));
-    } catch (e) {
-      window.lana?.log(`Message: Skipping image dimension check (unreadable), Error: ${e}`, this.lanaOptions);
-      return null;
-    }
+    } catch (e) { return null; }
     const isMaxLimits = this.limits.maxWidth && this.limits.maxHeight;
     const isMinLimits = this.limits.minWidth && this.limits.minHeight;
     this.filesData = { ...this.filesData, width, height };

--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -398,7 +398,13 @@ export default class ActionBinder {
 
   async checkImageDimensions(file) {
     const { getImageDimensions } = await import(`${getUnityLibs()}/utils/FileUtils.js`);
-    const { width, height } = await getImageDimensions(file);
+    let { width, height } = {};
+    try {
+      ({ width, height } = await getImageDimensions(file));
+    } catch (e) {
+      window.lana?.log(`Message: Skipping image dimension check (unreadable), Error: ${e}`, this.lanaOptions);
+      return null;
+    }
     const isMaxLimits = this.limits.maxWidth && this.limits.maxHeight;
     const isMinLimits = this.limits.minWidth && this.limits.minHeight;
     this.filesData = { ...this.filesData, width, height };


### PR DESCRIPTION
 skip file dimension check if not able to get width/height of image
please check the slack thread for asset details:
https://adobe-mwp.slack.com/archives/C0AE5AP6Q9L/p1778625759895929
Resolves: [MWPW-193816](https://jira.corp.adobe.com/browse/MWPW-193816)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/firefly/features/ai-image-expander
- After: https://main--da-cc--adobecom.aem.page/products/firefly/features/ai-image-expander?unitylibs=mwpw-193816
