### PR TITLE
[MWPW-195823]Remove batch3 verbs from experimentationOn array

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -18,7 +18,7 @@
     "nonpdfSfuProductScreen": ["word-to-pdf", "jpg-to-pdf", "ppt-to-pdf", "excel-to-pdf", "png-to-pdf", "createpdf", "chat-pdf", "chat-pdf-student", "summarize-pdf", "pdf-ai", "heic-to-pdf", "quiz-maker", "flashcard-maker", "mindmap-maker"],
     "mfuUploadAllowed": ["combine-pdf", "rotate-pages", "chat-pdf", "chat-pdf-student", "summarize-pdf", "pdf-ai", "quiz-maker", "flashcard-maker", "mindmap-maker"],
     "mfuUploadOnlyPdfAllowed": ["combine-pdf"],
-    "experimentationOn": [],
+    "experimentationOn": ["add-comment"],
     "fetchApiConfig": {
       "finalizeAsset": {
         "retryType": "polling",

--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -18,7 +18,7 @@
     "nonpdfSfuProductScreen": ["word-to-pdf", "jpg-to-pdf", "ppt-to-pdf", "excel-to-pdf", "png-to-pdf", "createpdf", "chat-pdf", "chat-pdf-student", "summarize-pdf", "pdf-ai", "heic-to-pdf", "quiz-maker", "flashcard-maker", "mindmap-maker"],
     "mfuUploadAllowed": ["combine-pdf", "rotate-pages", "chat-pdf", "chat-pdf-student", "summarize-pdf", "pdf-ai", "quiz-maker", "flashcard-maker", "mindmap-maker"],
     "mfuUploadOnlyPdfAllowed": ["combine-pdf"],
-    "experimentationOn": ["add-comment", "png-to-pdf", "jpg-to-pdf", "ppt-to-pdf", "excel-to-pdf", "createpdf"],
+    "experimentationOn": [],
     "fetchApiConfig": {
       "finalizeAsset": {
         "retryType": "polling",


### PR DESCRIPTION
* Remove batch3 verbs from experimentationOn array

Resolves: [MWPW-195823](https://jira.corp.adobe.com/browse/MWPW-195823)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.live/acrobat/online/excel-to-pdf?martech=off&unitylibs=stage
- After: https://main--da-dc--adobecom.aem.live/acrobat/online/excel-to-pdf?martech=off&unitylibs=MWPW-195823

**Note:**
* This PR will be added to release PR post confirmation in slack channel here https://adobe-mwp.slack.com/archives/C07KDG7JK3J/p1779207830419349 **Update:** Got confirmation on slack that add-comment should stay hence added it back. All other batch3 verbs are removed.
* We are targeting this PR to be part of tomorrow's release.

Testing Notes:
* Please perform regression for acrobat workflow
