### PR TITLE
[AEEE-35242] fix for Play button for non-selected voices doesn't appear on Android mobile

### DIFF
--- a/unitylibs/core/widgets/prompt-bar-audio/prompt-bar-audio.css
+++ b/unitylibs/core/widgets/prompt-bar-audio/prompt-bar-audio.css
@@ -201,7 +201,7 @@
   opacity: 1;
 }
 
-@media (hover: none) {
+@media (hover: none), (pointer: coarse) {
   .unity-prompt-bar-audio .unity-paf-voice-tile .unity-paf-voice-player {
     opacity: 1;
   }


### PR DESCRIPTION
fix for Play button for non-selected voices doesn't appear on Android mobile


Resolves: [AEEE-35242](https://jira.corp.adobe.com/browse/AEEE-35242)

**Test URLs:** to be checked across devices particularly on touch devices (android and ios)
- Before: https://main--da-cc--adobecom.aem.page/products/firefly/features/ai-voice-generator
- After: https://main--da-cc--adobecom.aem.page/products/firefly/features/ai-voice-generator?unitylibs=aeee-35242
