### PR TITLE
Allow word doc file for resume-builder verb

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -18,7 +18,7 @@
     "directUploadVerbs": ["word-to-pdf"],
     "directUploadMaxSize": 1048576,
     "nonpdfMfuFeedbackScreenTypeNonpdf": ["combine-pdf"],
-    "nonpdfSfuProductScreen": ["word-to-pdf", "jpg-to-pdf", "ppt-to-pdf", "excel-to-pdf", "png-to-pdf", "createpdf", "chat-pdf", "chat-pdf-student", "summarize-pdf", "pdf-ai", "heic-to-pdf", "quiz-maker", "flashcard-maker", "mindmap-maker"],
+    "nonpdfSfuProductScreen": ["word-to-pdf", "jpg-to-pdf", "ppt-to-pdf", "excel-to-pdf", "png-to-pdf", "createpdf", "chat-pdf", "chat-pdf-student", "summarize-pdf", "pdf-ai", "heic-to-pdf", "quiz-maker", "flashcard-maker", "mindmap-maker", "resume-builder"],
     "mfuUploadAllowed": ["combine-pdf", "rotate-pages", "chat-pdf", "chat-pdf-student", "summarize-pdf", "pdf-ai", "quiz-maker", "flashcard-maker", "mindmap-maker"],
     "mfuUploadOnlyPdfAllowed": ["combine-pdf"],
     "experimentationOn": ["add-comment"],


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Allow word doc file for resume-builder verb


Resolves: [MWPW-196557](https://jira.corp.adobe.com/browse/MWPW-196557)

**Test URLs:**
- Before: https://stage--da-dc--adobecom.aem.page/acrobat/online/ai-resume-builder?martech=off&unitylibs=stage&app!versions=latest
- After: https://stage--da-dc--adobecom.aem.page/acrobat/online/ai-resume-builder?martech=off&unitylibs=resume-builder-word-doc&app!versions=latest
