### PR TITLE
[MWPW-198610] Mobile tab experience

### DIFF
--- a/test/utils/device.detection.test.js
+++ b/test/utils/device.detection.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable quote-props */
 /* eslint-disable quotes */
 import { expect } from '@esm-bundle/chai';
-import isDesktop from '../../unitylibs/utils/device-detection.js';
+import isDesktop, { isIOSWebKit } from '../../unitylibs/utils/device-detection.js';
 
 describe('Device Detection', () => {
   let originalNavigator;
@@ -85,5 +85,27 @@ describe('Device Detection', () => {
     Object.defineProperty(navigator, 'maxTouchPoints', { value: 5, configurable: true });
     const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Touch Tablet PC';
     expect(isDesktop(userAgent)).to.equal(false);
+  });
+
+  it('should detect iPhone as iOS WebKit', () => {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1';
+    expect(isIOSWebKit(userAgent)).to.equal(true);
+  });
+
+  it('should detect iPad as iOS WebKit', () => {
+    const userAgent = 'Mozilla/5.0 (iPad; CPU OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1';
+    expect(isIOSWebKit(userAgent)).to.equal(true);
+  });
+
+  it('should detect iPadOS Mac UA with touch as iOS WebKit', () => {
+    Object.defineProperty(navigator, 'maxTouchPoints', { value: 5, configurable: true });
+    Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15', configurable: true });
+    expect(isIOSWebKit()).to.equal(true);
+  });
+
+  it('should not detect macOS desktop as iOS WebKit', () => {
+    Object.defineProperty(navigator, 'maxTouchPoints', { value: 0, configurable: true });
+    const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36';
+    expect(isIOSWebKit(userAgent)).to.equal(false);
   });
 });

--- a/test/utils/device.detection.test.js
+++ b/test/utils/device.detection.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable quote-props */
 /* eslint-disable quotes */
 import { expect } from '@esm-bundle/chai';
-import isDesktop, { isIOSWebKit } from '../../unitylibs/utils/device-detection.js';
+import isDesktop from '../../unitylibs/utils/device-detection.js';
 
 describe('Device Detection', () => {
   let originalNavigator;
@@ -85,27 +85,5 @@ describe('Device Detection', () => {
     Object.defineProperty(navigator, 'maxTouchPoints', { value: 5, configurable: true });
     const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Touch Tablet PC';
     expect(isDesktop(userAgent)).to.equal(false);
-  });
-
-  it('should detect iPhone as iOS WebKit', () => {
-    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1';
-    expect(isIOSWebKit(userAgent)).to.equal(true);
-  });
-
-  it('should detect iPad as iOS WebKit', () => {
-    const userAgent = 'Mozilla/5.0 (iPad; CPU OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1';
-    expect(isIOSWebKit(userAgent)).to.equal(true);
-  });
-
-  it('should detect iPadOS Mac UA with touch as iOS WebKit', () => {
-    Object.defineProperty(navigator, 'maxTouchPoints', { value: 5, configurable: true });
-    Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15', configurable: true });
-    expect(isIOSWebKit()).to.equal(true);
-  });
-
-  it('should not detect macOS desktop as iOS WebKit', () => {
-    Object.defineProperty(navigator, 'maxTouchPoints', { value: 0, configurable: true });
-    const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36';
-    expect(isIOSWebKit(userAgent)).to.equal(false);
   });
 });

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -15,8 +15,7 @@ import {
 } from '../../../scripts/utils.js';
 import { InlineActionState } from '../../widgets/inline-action/inline-action.js';
 import { INLINE_ACTION_EVENTS } from '../../../scripts/analytics.js';
-import isDesktop from '../../../utils/device-detection.js';
-import { getCgenQueryParams } from '../../../utils/cgen-utils.js';
+import isDesktop, { isIOS } from '../../../utils/device-detection.js';
 
 const DOWNLOAD_COUNT_KEY = 'inline-action-download-count';
 const WORKFLOW_NAME = 'inline-action';
@@ -403,7 +402,8 @@ export default class ActionBinder {
     return el?.dataset?.nba;
   }
 
-  buildConnectorPayload({ defaultPrompt, verb, connectorAssetId, fileType } = {}) {
+  async buildConnectorPayload({ defaultPrompt, verb, connectorAssetId, fileType } = {}) {
+    const { getCgenQueryParams } = await import(`${getUnityLibs()}/utils/cgen-utils.js`);
     const query = defaultPrompt?.trim();
     return {
       assetId: connectorAssetId,
@@ -582,12 +582,22 @@ export default class ActionBinder {
     await this.triggerDownload(this.resultUrl);
   }
 
+  async runFirstLocalDownload() {
+    try {
+      await this.startLocalDownload();
+      this.incrementUserCount();
+      this.trackEvent(INLINE_ACTION_EVENTS.DOWNLOAD_SUCCESS, { assetId: this.resultAssetId, fileMetaData: this.filesData });
+    } catch (e) {
+      this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
+    }
+  }
+
   async handleConnector(el, isDownload = false) {
-    const openInSameTab = !isDesktop();
     const userCount = this.getUserCount();
+    const openInSameTab = !isDesktop();
     const downloadsLocally = isDownload && userCount < 1;
     const verb = this.resolveConnectorVerb(el, isDownload, downloadsLocally);
-    const connectorPayload = this.buildConnectorPayload({
+    const connectorPayload = await this.buildConnectorPayload({
       defaultPrompt: el?.dataset?.defaultPrompt,
       verb,
       connectorAssetId: this.resultAssetId,
@@ -595,38 +605,13 @@ export default class ActionBinder {
     });
 
     if (downloadsLocally) {
-      let connectorUrl;
+      await this.runFirstLocalDownload();
+      if (isIOS()) return;
       try {
-        const res = await this.serviceHandler.postCallToService(
-          this.apiConfig.connectorApiEndPoint,
-          { body: JSON.stringify(connectorPayload) },
-          this.uploadErrorOpts(),
-        );
-        if (!res?.url) {
-          const error = new Error('Error connecting to App');
-          error.status = res?.status;
-          throw error;
-        }
-        connectorUrl = res.url;
-      } catch (e) {
-        this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
-        return;
-      }
-
-      try {
-        await this.startLocalDownload();
-        this.incrementUserCount();
-        this.trackEvent(INLINE_ACTION_EVENTS.DOWNLOAD_SUCCESS, { assetId: this.resultAssetId, fileMetaData: this.filesData });
+        await this.callConnector(connectorPayload, { openInSameTab, useSplashProgress: false });
       } catch (e) {
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
       }
-
-      // Defer navigation so the browser has a chance to show the download popup before
-      // the current page navigates away. On Android, the download manager handles the
-      // file independently so it completes even after navigation.
-      setTimeout(() => {
-        this.navigateToConnectorUrl(connectorUrl, { openInSameTab, useSplashProgress: false });
-      }, 100);
       return;
     }
 

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -495,6 +495,30 @@ export default class ActionBinder {
     }, 200);
   }
 
+  /**
+   * iOS blocks same-tab navigation after a same-tab programmatic download click.
+   * Open the file in a new context (target=_blank), then redirect the current tab.
+   */
+  triggerMobileLocalDownload() {
+    const mimeType = this.resultBlob?.type || this.filesData.type || 'image/png';
+    const url = this.resultBlob?.size
+      ? URL.createObjectURL(this.resultBlob)
+      : this.resultUrl;
+    if (!url) throw new Error('No download URL available');
+    const a = createTag('a', {
+      href: url,
+      download: ActionBinder.downloadFilename(mimeType),
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    });
+    document.body.append(a);
+    a.click();
+    setTimeout(() => {
+      a.remove();
+      if (this.resultBlob?.size) URL.revokeObjectURL(url);
+    }, 200);
+  }
+
   async triggerDownload(url) {
     const blob = await this.resolveDownloadBlob(url);
     this.downloadBlob(blob, blob.type || 'image/png');
@@ -597,22 +621,32 @@ export default class ActionBinder {
     });
 
     if (downloadsLocally) {
-      // Start connector fetch before download — Safari blocks fetch() started after a file download.
-      const connectorPromise = this.callConnector(connectorPayload, {
-        openInSameTab,
-        useSplashProgress: false,
-        deferNavigation: true,
-      });
+      let res;
+      try {
+        res = await this.callConnector(connectorPayload, { deferNavigation: true });
+      } catch (e) {
+        this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
+        return;
+      }
+
+      if (openInSameTab) {
+        // Redirect first (same as NBA/Edit). A download click before location.href blocks iOS navigation.
+        this.navigateToConnectorUrl(res.url, { openInSameTab: true, useSplashProgress: false });
+        try {
+          this.triggerMobileLocalDownload();
+          this.incrementUserCount();
+          this.trackEvent(INLINE_ACTION_EVENTS.DOWNLOAD_SUCCESS, { assetId: this.resultAssetId, fileMetaData: this.filesData });
+        } catch (e) {
+          window.lana?.log(`Message: Mobile download after redirect failed, Error: ${e}`, this.lanaOptions);
+        }
+        return;
+      }
+
+      this.navigateToConnectorUrl(res.url, { openInSameTab: false, useSplashProgress: false });
       try {
         await this.startLocalDownload();
         this.incrementUserCount();
         this.trackEvent(INLINE_ACTION_EVENTS.DOWNLOAD_SUCCESS, { assetId: this.resultAssetId, fileMetaData: this.filesData });
-      } catch (e) {
-        this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
-      }
-      try {
-        const res = await connectorPromise;
-        this.navigateToConnectorUrl(res.url, { openInSameTab, useSplashProgress: false });
       } catch (e) {
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
       }

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -437,10 +437,10 @@ export default class ActionBinder {
         this.transitionScreen.LOADER_LIMIT = PROGRESS.COMPLETE;
         this.setProgress(PROGRESS.COMPLETE, true);
       }
-      window.location.replace(res.url);
+      window.location.href = res.url;
     } else {
       const opened = window.open(res.url, '_blank');
-      if (!opened) window.location.replace(res.url);
+      if (!opened) window.location.href = res.url;
     }
     return res;
   }
@@ -584,12 +584,16 @@ export default class ActionBinder {
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
       }
     }
-    await this.callConnector(await this.buildConnectorPayload({
-      defaultPrompt: el?.dataset?.defaultPrompt,
-      verb,
-      connectorAssetId: this.resultAssetId,
-      fileType: this.filesData.type,
-    }), { openInSameTab });
+    try {
+      await this.callConnector(await this.buildConnectorPayload({
+        defaultPrompt: el?.dataset?.defaultPrompt,
+        verb,
+        connectorAssetId: this.resultAssetId,
+        fileType: this.filesData.type,
+      }), { openInSameTab });
+    } catch (e) {
+      this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
+    }
   }
 
   async createErrorToast() {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -595,6 +595,12 @@ export default class ActionBinder {
     });
 
     if (downloadsLocally) {
+      // On mobile, open a blank window now — synchronously, while still within the user gesture
+      // context so popup blockers allow it. We'll navigate it to the connector URL after the
+      // async work is done. This keeps the current tab in place so the download/QuickLook
+      // preview isn't dismissed by our own navigation.
+      const mobileConnectorWindow = openInSameTab ? window.open('', '_blank') : null;
+
       let connectorUrl;
       try {
         const res = await this.serviceHandler.postCallToService(
@@ -609,9 +615,11 @@ export default class ActionBinder {
         }
         connectorUrl = res.url;
       } catch (e) {
+        mobileConnectorWindow?.close();
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
         return;
       }
+
       try {
         await this.startLocalDownload();
         this.incrementUserCount();
@@ -619,7 +627,12 @@ export default class ActionBinder {
       } catch (e) {
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
       }
-      this.navigateToConnectorUrl(connectorUrl, { openInSameTab, useSplashProgress: false });
+
+      if (mobileConnectorWindow) {
+        mobileConnectorWindow.location.href = connectorUrl;
+      } else {
+        this.navigateToConnectorUrl(connectorUrl, { openInSameTab: false, useSplashProgress: false });
+      }
       return;
     }
 

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -15,7 +15,6 @@ import {
 } from '../../../scripts/utils.js';
 import { InlineActionState } from '../../widgets/inline-action/inline-action.js';
 import { INLINE_ACTION_EVENTS } from '../../../scripts/analytics.js';
-import isDesktop, { isIOSSafari } from '../../../utils/device-detection.js';
 
 const DOWNLOAD_COUNT_KEY = 'inline-action-download-count';
 const WORKFLOW_NAME = 'inline-action';
@@ -585,6 +584,7 @@ export default class ActionBinder {
   }
 
   async handleConnector(el, isDownload = false) {
+    const { default: isDesktop, isIOSSafari } = await import(`${getUnityLibs()}/utils/device-detection.js`);
     const userCount = this.getUserCount();
     const openInSameTab = !isDesktop();
     const downloadsLocally = isDownload && userCount < 1;

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -570,25 +570,35 @@ export default class ActionBinder {
     else await this.anonymousFlow(file);
   }
 
+  startLocalDownload() {
+    if (this.resultBlob?.size) {
+      this.downloadBlob(this.resultBlob, this.resultBlob.type || 'image/png');
+      return;
+    }
+    this.triggerDownload(this.resultUrl).catch((e) => {
+      this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
+    });
+  }
+
   async handleConnector(el, isDownload = false) {
-    let userCount = this.getUserCount();
+    const userCount = this.getUserCount();
     const downloadsLocally = isDownload && userCount < 1;
     const verb = this.resolveConnectorVerb(el, isDownload, downloadsLocally);
     if (downloadsLocally) {
-      try {
-        await this.triggerDownload(this.resultUrl);
-        userCount = this.incrementUserCount();
-        this.trackEvent(INLINE_ACTION_EVENTS.DOWNLOAD_SUCCESS, { assetId: this.resultAssetId, fileMetaData: this.filesData });
-      } catch (e) {
-        this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
-      }
+      this.startLocalDownload();
+      this.incrementUserCount();
+      this.trackEvent(INLINE_ACTION_EVENTS.DOWNLOAD_SUCCESS, { assetId: this.resultAssetId, fileMetaData: this.filesData });
     }
-    await this.callConnector(await this.buildConnectorPayload({
-      defaultPrompt: el?.dataset?.defaultPrompt,
-      verb,
-      connectorAssetId: this.resultAssetId,
-      fileType: this.filesData.type,
-    }), { openInSameTab: !isDesktop(), useSplashProgress: false });
+    try {
+      await this.callConnector(await this.buildConnectorPayload({
+        defaultPrompt: el?.dataset?.defaultPrompt,
+        verb,
+        connectorAssetId: this.resultAssetId,
+        fileType: this.filesData.type,
+      }), { openInSameTab: !isDesktop(), useSplashProgress: false });
+    } catch (e) {
+      this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
+    }
   }
 
   async createErrorToast() {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -570,17 +570,13 @@ export default class ActionBinder {
     else await this.anonymousFlow(file);
   }
 
-  async startLocalDownload() {
-    if (this.resultBlob?.size) {
-      this.downloadBlob(this.resultBlob, this.resultBlob.type || 'image/png');
-      return;
-    }
-    await this.triggerDownload(this.resultUrl);
-  }
-
   async runFirstLocalDownload() {
     try {
-      await this.startLocalDownload();
+      if (this.resultBlob?.size) {
+        this.downloadBlob(this.resultBlob, this.resultBlob.type || 'image/png');
+      } else {
+        await this.triggerDownload(this.resultUrl);
+      }
       this.incrementUserCount();
       this.trackEvent(INLINE_ACTION_EVENTS.DOWNLOAD_SUCCESS, { assetId: this.resultAssetId, fileMetaData: this.filesData });
     } catch (e) {
@@ -599,19 +595,11 @@ export default class ActionBinder {
       connectorAssetId: this.resultAssetId,
       fileType: this.filesData.type,
     });
-
     if (downloadsLocally) {
       await this.runFirstLocalDownload();
       if (isIOSSafari()) return;
       await new Promise((resolve) => { setTimeout(resolve, 200); });
-      try {
-        await this.callConnector(connectorPayload, { openInSameTab, useSplashProgress: false });
-      } catch (e) {
-        this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
-      }
-      return;
     }
-
     try {
       await this.callConnector(connectorPayload, { openInSameTab, useSplashProgress: false });
     } catch (e) {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -495,30 +495,6 @@ export default class ActionBinder {
     }, 200);
   }
 
-  /**
-   * iOS blocks same-tab navigation after a same-tab programmatic download click.
-   * Open the file in a new context (target=_blank), then redirect the current tab.
-   */
-  triggerMobileLocalDownload() {
-    const mimeType = this.resultBlob?.type || this.filesData.type || 'image/png';
-    const url = this.resultBlob?.size
-      ? URL.createObjectURL(this.resultBlob)
-      : this.resultUrl;
-    if (!url) throw new Error('No download URL available');
-    const a = createTag('a', {
-      href: url,
-      download: ActionBinder.downloadFilename(mimeType),
-      target: '_blank',
-      rel: 'noopener noreferrer',
-    });
-    document.body.append(a);
-    a.click();
-    setTimeout(() => {
-      a.remove();
-      if (this.resultBlob?.size) URL.revokeObjectURL(url);
-    }, 200);
-  }
-
   async triggerDownload(url) {
     const blob = await this.resolveDownloadBlob(url);
     this.downloadBlob(blob, blob.type || 'image/png');
@@ -621,28 +597,6 @@ export default class ActionBinder {
     });
 
     if (downloadsLocally) {
-      let res;
-      try {
-        res = await this.callConnector(connectorPayload, { deferNavigation: true });
-      } catch (e) {
-        this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
-        return;
-      }
-
-      if (openInSameTab) {
-        // Redirect first (same as NBA/Edit). A download click before location.href blocks iOS navigation.
-        this.navigateToConnectorUrl(res.url, { openInSameTab: true, useSplashProgress: false });
-        try {
-          this.triggerMobileLocalDownload();
-          this.incrementUserCount();
-          this.trackEvent(INLINE_ACTION_EVENTS.DOWNLOAD_SUCCESS, { assetId: this.resultAssetId, fileMetaData: this.filesData });
-        } catch (e) {
-          window.lana?.log(`Message: Mobile download after redirect failed, Error: ${e}`, this.lanaOptions);
-        }
-        return;
-      }
-
-      this.navigateToConnectorUrl(res.url, { openInSameTab: false, useSplashProgress: false });
       try {
         await this.startLocalDownload();
         this.incrementUserCount();
@@ -650,7 +604,6 @@ export default class ActionBinder {
       } catch (e) {
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
       }
-      return;
     }
 
     try {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -421,7 +421,7 @@ export default class ActionBinder {
     };
   }
 
-  async callConnector(cOpts, { openInSameTab = false } = {}) {
+  async callConnector(cOpts, { openInSameTab = false, useSplashProgress = false } = {}) {
     const res = await this.serviceHandler.postCallToService(
       this.apiConfig.connectorApiEndPoint,
       { body: JSON.stringify(cOpts) },
@@ -433,7 +433,7 @@ export default class ActionBinder {
       throw error;
     }
     if (openInSameTab) {
-      if (this.transitionScreen?.splashScreenEl) {
+      if (useSplashProgress && this.transitionScreen?.splashScreenEl) {
         this.transitionScreen.LOADER_LIMIT = PROGRESS.COMPLETE;
         this.setProgress(PROGRESS.COMPLETE, true);
       }
@@ -522,7 +522,7 @@ export default class ActionBinder {
         verb: 'aiPhotoEditor',
         connectorAssetId: this.resultAssetId,
         fileType: this.filesData.type,
-      }), { openInSameTab: true });
+      }), { openInSameTab: true, useSplashProgress: true });
     } catch (e) {
       await this.transitionScreen?.showSplashScreen(false);
       if (e.name !== 'AbortError') {
@@ -590,7 +590,7 @@ export default class ActionBinder {
         verb,
         connectorAssetId: this.resultAssetId,
         fileType: this.filesData.type,
-      }), { openInSameTab });
+      }), { openInSameTab, useSplashProgress: false });
     } catch (e) {
       this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
     }

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -434,7 +434,7 @@ export default class ActionBinder {
     if (!opened) window.location.href = url;
   }
 
-  async callConnector(cOpts, { openInSameTab = false, useSplashProgress = false, deferNavigation = false } = {}) {
+  async callConnector(cOpts, { openInSameTab = false, useSplashProgress = false } = {}) {
     const res = await this.serviceHandler.postCallToService(
       this.apiConfig.connectorApiEndPoint,
       { body: JSON.stringify(cOpts) },
@@ -445,9 +445,7 @@ export default class ActionBinder {
       error.status = res?.status;
       throw error;
     }
-    if (!deferNavigation) {
-      this.navigateToConnectorUrl(res.url, { openInSameTab, useSplashProgress });
-    }
+    this.navigateToConnectorUrl(res.url, { openInSameTab, useSplashProgress });
     return res;
   }
 

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -15,7 +15,7 @@ import {
 } from '../../../scripts/utils.js';
 import { InlineActionState } from '../../widgets/inline-action/inline-action.js';
 import { INLINE_ACTION_EVENTS } from '../../../scripts/analytics.js';
-import { isIOSWebKit } from '../../../utils/device-detection.js';
+import isDesktop from '../../../utils/device-detection.js';
 
 const DOWNLOAD_COUNT_KEY = 'inline-action-download-count';
 const WORKFLOW_NAME = 'inline-action';
@@ -421,7 +421,7 @@ export default class ActionBinder {
     };
   }
 
-  async callConnector(cOpts, { openInSameTab = false, popup = null } = {}) {
+  async callConnector(cOpts, { openInSameTab = false } = {}) {
     const res = await this.serviceHandler.postCallToService(
       this.apiConfig.connectorApiEndPoint,
       { body: JSON.stringify(cOpts) },
@@ -436,8 +436,6 @@ export default class ActionBinder {
       if (this.transitionScreen) this.transitionScreen.LOADER_LIMIT = PROGRESS.COMPLETE;
       this.setProgress(PROGRESS.COMPLETE, true);
       window.location.assign(res.url);
-    } else if (popup && !popup.closed) {
-      popup.location.replace(res.url);
     } else {
       window.open(res.url, '_blank');
     }
@@ -573,7 +571,6 @@ export default class ActionBinder {
     let userCount = this.getUserCount();
     const downloadsLocally = isDownload && userCount < 1;
     const verb = this.resolveConnectorVerb(el, isDownload, downloadsLocally);
-    const popup = isIOSWebKit() ? window.open('about:blank', '_blank') : null;
     if (downloadsLocally) {
       try {
         await this.triggerDownload(this.resultUrl);
@@ -588,7 +585,7 @@ export default class ActionBinder {
       verb,
       connectorAssetId: this.resultAssetId,
       fileType: this.filesData.type,
-    }), { popup });
+    }), { openInSameTab: !isDesktop() });
   }
 
   async createErrorToast() {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -421,7 +421,20 @@ export default class ActionBinder {
     };
   }
 
-  async callConnector(cOpts, { openInSameTab = false, useSplashProgress = false } = {}) {
+  navigateToConnectorUrl(url, { openInSameTab = false, useSplashProgress = false } = {}) {
+    if (openInSameTab) {
+      if (useSplashProgress && this.transitionScreen?.splashScreenEl) {
+        this.transitionScreen.LOADER_LIMIT = PROGRESS.COMPLETE;
+        this.setProgress(PROGRESS.COMPLETE, true);
+      }
+      window.location.href = url;
+      return;
+    }
+    const opened = window.open(url, '_blank');
+    if (!opened) window.location.href = url;
+  }
+
+  async callConnector(cOpts, { openInSameTab = false, useSplashProgress = false, deferNavigation = false } = {}) {
     const res = await this.serviceHandler.postCallToService(
       this.apiConfig.connectorApiEndPoint,
       { body: JSON.stringify(cOpts) },
@@ -432,15 +445,8 @@ export default class ActionBinder {
       error.status = res?.status;
       throw error;
     }
-    if (openInSameTab) {
-      if (useSplashProgress && this.transitionScreen?.splashScreenEl) {
-        this.transitionScreen.LOADER_LIMIT = PROGRESS.COMPLETE;
-        this.setProgress(PROGRESS.COMPLETE, true);
-      }
-      window.location.href = res.url;
-    } else {
-      const opened = window.open(res.url, '_blank');
-      if (!opened) window.location.href = res.url;
+    if (!deferNavigation) {
+      this.navigateToConnectorUrl(res.url, { openInSameTab, useSplashProgress });
     }
     return res;
   }
@@ -589,7 +595,14 @@ export default class ActionBinder {
       connectorAssetId: this.resultAssetId,
       fileType: this.filesData.type,
     });
+
     if (downloadsLocally) {
+      // Start connector fetch before download — Safari blocks fetch() started after a file download.
+      const connectorPromise = this.callConnector(connectorPayload, {
+        openInSameTab,
+        useSplashProgress: false,
+        deferNavigation: true,
+      });
       try {
         await this.startLocalDownload();
         this.incrementUserCount();
@@ -597,7 +610,15 @@ export default class ActionBinder {
       } catch (e) {
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
       }
+      try {
+        const res = await connectorPromise;
+        this.navigateToConnectorUrl(res.url, { openInSameTab, useSplashProgress: false });
+      } catch (e) {
+        this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
+      }
+      return;
     }
+
     try {
       await this.callConnector(connectorPayload, { openInSameTab, useSplashProgress: false });
     } catch (e) {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -595,6 +595,23 @@ export default class ActionBinder {
     });
 
     if (downloadsLocally) {
+      let connectorUrl;
+      try {
+        const res = await this.serviceHandler.postCallToService(
+          this.apiConfig.connectorApiEndPoint,
+          { body: JSON.stringify(connectorPayload) },
+          this.uploadErrorOpts(),
+        );
+        if (!res?.url) {
+          const error = new Error('Error connecting to App');
+          error.status = res?.status;
+          throw error;
+        }
+        connectorUrl = res.url;
+      } catch (e) {
+        this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
+        return;
+      }
       try {
         await this.startLocalDownload();
         this.incrementUserCount();
@@ -602,6 +619,8 @@ export default class ActionBinder {
       } catch (e) {
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
       }
+      this.navigateToConnectorUrl(connectorUrl, { openInSameTab, useSplashProgress: false });
+      return;
     }
 
     try {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -433,11 +433,14 @@ export default class ActionBinder {
       throw error;
     }
     if (openInSameTab) {
-      if (this.transitionScreen) this.transitionScreen.LOADER_LIMIT = PROGRESS.COMPLETE;
-      this.setProgress(PROGRESS.COMPLETE, true);
-      window.location.assign(res.url);
+      if (this.transitionScreen?.splashScreenEl) {
+        this.transitionScreen.LOADER_LIMIT = PROGRESS.COMPLETE;
+        this.setProgress(PROGRESS.COMPLETE, true);
+      }
+      window.location.replace(res.url);
     } else {
-      window.open(res.url, '_blank');
+      const opened = window.open(res.url, '_blank');
+      if (!opened) window.location.replace(res.url);
     }
     return res;
   }
@@ -568,6 +571,7 @@ export default class ActionBinder {
   }
 
   async handleConnector(el, isDownload = false) {
+    const openInSameTab = !isDesktop();
     let userCount = this.getUserCount();
     const downloadsLocally = isDownload && userCount < 1;
     const verb = this.resolveConnectorVerb(el, isDownload, downloadsLocally);
@@ -585,7 +589,7 @@ export default class ActionBinder {
       verb,
       connectorAssetId: this.resultAssetId,
       fileType: this.filesData.type,
-    }), { openInSameTab: !isDesktop() });
+    }), { openInSameTab });
   }
 
   async createErrorToast() {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -603,6 +603,7 @@ export default class ActionBinder {
     if (downloadsLocally) {
       await this.runFirstLocalDownload();
       if (isIOSSafari()) return;
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
       try {
         await this.callConnector(connectorPayload, { openInSameTab, useSplashProgress: false });
       } catch (e) {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -15,6 +15,7 @@ import {
 } from '../../../scripts/utils.js';
 import { InlineActionState } from '../../widgets/inline-action/inline-action.js';
 import { INLINE_ACTION_EVENTS } from '../../../scripts/analytics.js';
+import { isIOSWebKit } from '../../../utils/device-detection.js';
 
 const DOWNLOAD_COUNT_KEY = 'inline-action-download-count';
 const WORKFLOW_NAME = 'inline-action';
@@ -420,7 +421,7 @@ export default class ActionBinder {
     };
   }
 
-  async callConnector(cOpts, { openInSameTab = false } = {}) {
+  async callConnector(cOpts, { openInSameTab = false, popup = null } = {}) {
     const res = await this.serviceHandler.postCallToService(
       this.apiConfig.connectorApiEndPoint,
       { body: JSON.stringify(cOpts) },
@@ -435,6 +436,8 @@ export default class ActionBinder {
       if (this.transitionScreen) this.transitionScreen.LOADER_LIMIT = PROGRESS.COMPLETE;
       this.setProgress(PROGRESS.COMPLETE, true);
       window.location.assign(res.url);
+    } else if (popup && !popup.closed) {
+      popup.location.replace(res.url);
     } else {
       window.open(res.url, '_blank');
     }
@@ -570,6 +573,7 @@ export default class ActionBinder {
     let userCount = this.getUserCount();
     const downloadsLocally = isDownload && userCount < 1;
     const verb = this.resolveConnectorVerb(el, isDownload, downloadsLocally);
+    const popup = isIOSWebKit() ? window.open('about:blank', '_blank') : null;
     if (downloadsLocally) {
       try {
         await this.triggerDownload(this.resultUrl);
@@ -577,7 +581,6 @@ export default class ActionBinder {
         this.trackEvent(INLINE_ACTION_EVENTS.DOWNLOAD_SUCCESS, { assetId: this.resultAssetId, fileMetaData: this.filesData });
       } catch (e) {
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
-        return;
       }
     }
     await this.callConnector(await this.buildConnectorPayload({
@@ -585,7 +588,7 @@ export default class ActionBinder {
       verb,
       connectorAssetId: this.resultAssetId,
       fileType: this.filesData.type,
-    }));
+    }), { popup });
   }
 
   async createErrorToast() {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -603,7 +603,7 @@ export default class ActionBinder {
     if (downloadsLocally) {
       await this.runFirstLocalDownload();
       if (isIOSSafari()) return;
-      await new Promise((resolve) => { setTimeout(resolve, 100); });
+      await new Promise((resolve) => { setTimeout(resolve, 200); });
       try {
         await this.callConnector(connectorPayload, { openInSameTab, useSplashProgress: false });
       } catch (e) {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -421,19 +421,6 @@ export default class ActionBinder {
     };
   }
 
-  navigateToConnectorUrl(url, { openInSameTab = false, useSplashProgress = false } = {}) {
-    if (openInSameTab) {
-      if (useSplashProgress && this.transitionScreen?.splashScreenEl) {
-        this.transitionScreen.LOADER_LIMIT = PROGRESS.COMPLETE;
-        this.setProgress(PROGRESS.COMPLETE, true);
-      }
-      window.location.href = url;
-      return;
-    }
-    const opened = window.open(url, '_blank');
-    if (!opened) window.location.href = url;
-  }
-
   async callConnector(cOpts, { openInSameTab = false, useSplashProgress = false } = {}) {
     const res = await this.serviceHandler.postCallToService(
       this.apiConfig.connectorApiEndPoint,
@@ -445,7 +432,16 @@ export default class ActionBinder {
       error.status = res?.status;
       throw error;
     }
-    this.navigateToConnectorUrl(res.url, { openInSameTab, useSplashProgress });
+    if (openInSameTab) {
+      if (useSplashProgress && this.transitionScreen?.splashScreenEl) {
+        this.transitionScreen.LOADER_LIMIT = PROGRESS.COMPLETE;
+        this.setProgress(PROGRESS.COMPLETE, true);
+      }
+      window.location.href = res.url;
+      return res;
+    }
+    const opened = window.open(res.url, '_blank');
+    if (!opened) window.location.href = res.url;
     return res;
   }
 

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -571,7 +571,6 @@ export default class ActionBinder {
   }
 
   async handleConnector(el, isDownload = false) {
-    const openInSameTab = !isDesktop();
     let userCount = this.getUserCount();
     const downloadsLocally = isDownload && userCount < 1;
     const verb = this.resolveConnectorVerb(el, isDownload, downloadsLocally);
@@ -584,16 +583,12 @@ export default class ActionBinder {
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
       }
     }
-    try {
-      await this.callConnector(await this.buildConnectorPayload({
-        defaultPrompt: el?.dataset?.defaultPrompt,
-        verb,
-        connectorAssetId: this.resultAssetId,
-        fileType: this.filesData.type,
-      }), { openInSameTab, useSplashProgress: false });
-    } catch (e) {
-      this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
-    }
+    await this.callConnector(await this.buildConnectorPayload({
+      defaultPrompt: el?.dataset?.defaultPrompt,
+      verb,
+      connectorAssetId: this.resultAssetId,
+      fileType: this.filesData.type,
+    }), { openInSameTab: !isDesktop(), useSplashProgress: false });
   }
 
   async createErrorToast() {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -15,7 +15,7 @@ import {
 } from '../../../scripts/utils.js';
 import { InlineActionState } from '../../widgets/inline-action/inline-action.js';
 import { INLINE_ACTION_EVENTS } from '../../../scripts/analytics.js';
-import isDesktop, { isIOS } from '../../../utils/device-detection.js';
+import isDesktop, { isIOSSafari } from '../../../utils/device-detection.js';
 
 const DOWNLOAD_COUNT_KEY = 'inline-action-download-count';
 const WORKFLOW_NAME = 'inline-action';
@@ -602,7 +602,7 @@ export default class ActionBinder {
 
     if (downloadsLocally) {
       await this.runFirstLocalDownload();
-      if (isIOS()) return;
+      if (isIOSSafari()) return;
       try {
         await this.callConnector(connectorPayload, { openInSameTab, useSplashProgress: false });
       } catch (e) {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -16,6 +16,7 @@ import {
 import { InlineActionState } from '../../widgets/inline-action/inline-action.js';
 import { INLINE_ACTION_EVENTS } from '../../../scripts/analytics.js';
 import isDesktop from '../../../utils/device-detection.js';
+import { getCgenQueryParams } from '../../../utils/cgen-utils.js';
 
 const DOWNLOAD_COUNT_KEY = 'inline-action-download-count';
 const WORKFLOW_NAME = 'inline-action';
@@ -402,8 +403,7 @@ export default class ActionBinder {
     return el?.dataset?.nba;
   }
 
-  async buildConnectorPayload({ defaultPrompt, verb, connectorAssetId, fileType } = {}) {
-    const { getCgenQueryParams } = await import(`${getUnityLibs()}/utils/cgen-utils.js`);
+  buildConnectorPayload({ defaultPrompt, verb, connectorAssetId, fileType } = {}) {
     const query = defaultPrompt?.trim();
     return {
       assetId: connectorAssetId,
@@ -583,6 +583,12 @@ export default class ActionBinder {
     const userCount = this.getUserCount();
     const downloadsLocally = isDownload && userCount < 1;
     const verb = this.resolveConnectorVerb(el, isDownload, downloadsLocally);
+    const connectorPayload = this.buildConnectorPayload({
+      defaultPrompt: el?.dataset?.defaultPrompt,
+      verb,
+      connectorAssetId: this.resultAssetId,
+      fileType: this.filesData.type,
+    });
     if (downloadsLocally) {
       try {
         await this.startLocalDownload();
@@ -593,12 +599,7 @@ export default class ActionBinder {
       }
     }
     try {
-      await this.callConnector(await this.buildConnectorPayload({
-        defaultPrompt: el?.dataset?.defaultPrompt,
-        verb,
-        connectorAssetId: this.resultAssetId,
-        fileType: this.filesData.type,
-      }), { openInSameTab, useSplashProgress: false });
+      await this.callConnector(connectorPayload, { openInSameTab, useSplashProgress: false });
     } catch (e) {
       this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
     }

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -595,12 +595,6 @@ export default class ActionBinder {
     });
 
     if (downloadsLocally) {
-      // On mobile, open a blank window now — synchronously, while still within the user gesture
-      // context so popup blockers allow it. We'll navigate it to the connector URL after the
-      // async work is done. This keeps the current tab in place so the download/QuickLook
-      // preview isn't dismissed by our own navigation.
-      const mobileConnectorWindow = openInSameTab ? window.open('', '_blank') : null;
-
       let connectorUrl;
       try {
         const res = await this.serviceHandler.postCallToService(
@@ -615,7 +609,6 @@ export default class ActionBinder {
         }
         connectorUrl = res.url;
       } catch (e) {
-        mobileConnectorWindow?.close();
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
         return;
       }
@@ -628,11 +621,12 @@ export default class ActionBinder {
         this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
       }
 
-      if (mobileConnectorWindow) {
-        mobileConnectorWindow.location.href = connectorUrl;
-      } else {
-        this.navigateToConnectorUrl(connectorUrl, { openInSameTab: false, useSplashProgress: false });
-      }
+      // Defer navigation so the browser has a chance to show the download popup before
+      // the current page navigates away. On Android, the download manager handles the
+      // file independently so it completes even after navigation.
+      setTimeout(() => {
+        this.navigateToConnectorUrl(connectorUrl, { openInSameTab, useSplashProgress: false });
+      }, 100);
       return;
     }
 

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -570,24 +570,27 @@ export default class ActionBinder {
     else await this.anonymousFlow(file);
   }
 
-  startLocalDownload() {
+  async startLocalDownload() {
     if (this.resultBlob?.size) {
       this.downloadBlob(this.resultBlob, this.resultBlob.type || 'image/png');
       return;
     }
-    this.triggerDownload(this.resultUrl).catch((e) => {
-      this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
-    });
+    await this.triggerDownload(this.resultUrl);
   }
 
   async handleConnector(el, isDownload = false) {
+    const openInSameTab = !isDesktop();
     const userCount = this.getUserCount();
     const downloadsLocally = isDownload && userCount < 1;
     const verb = this.resolveConnectorVerb(el, isDownload, downloadsLocally);
     if (downloadsLocally) {
-      this.startLocalDownload();
-      this.incrementUserCount();
-      this.trackEvent(INLINE_ACTION_EVENTS.DOWNLOAD_SUCCESS, { assetId: this.resultAssetId, fileMetaData: this.filesData });
+      try {
+        await this.startLocalDownload();
+        this.incrementUserCount();
+        this.trackEvent(INLINE_ACTION_EVENTS.DOWNLOAD_SUCCESS, { assetId: this.resultAssetId, fileMetaData: this.filesData });
+      } catch (e) {
+        this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
+      }
     }
     try {
       await this.callConnector(await this.buildConnectorPayload({
@@ -595,7 +598,7 @@ export default class ActionBinder {
         verb,
         connectorAssetId: this.resultAssetId,
         fileType: this.filesData.type,
-      }), { openInSameTab: !isDesktop(), useSplashProgress: false });
+      }), { openInSameTab, useSplashProgress: false });
     } catch (e) {
       this.serviceHandler.showErrorToast(this.uploadErrorOpts(), e, this.lanaOptions);
     }

--- a/unitylibs/utils/device-detection.js
+++ b/unitylibs/utils/device-detection.js
@@ -105,14 +105,6 @@ function getPlatformInfo(userAgent) {
   };
 }
 
-export function isIOSWebKit(userAgent) {
-  const ua = getUserAgent(userAgent);
-  if (getPlatformInfo(ua).platform === 'ios') return true;
-  if (isIPad(ua)) return true;
-  if (typeof navigator === 'undefined') return false;
-  return ua.includes('Mac') && navigator.maxTouchPoints > 1;
-}
-
 export default function isDesktop(userAgent) {
   const ua = getUserAgent(userAgent);
   if (isHeadlessBrowser(ua)) return true;

--- a/unitylibs/utils/device-detection.js
+++ b/unitylibs/utils/device-detection.js
@@ -105,7 +105,7 @@ function getPlatformInfo(userAgent) {
   };
 }
 
-export function isIOS(userAgent) {
+function isIOS(userAgent) {
   const ua = getUserAgent(userAgent);
   return isIPad(ua) || getPlatformInfo(ua).platform === 'ios';
 }

--- a/unitylibs/utils/device-detection.js
+++ b/unitylibs/utils/device-detection.js
@@ -105,6 +105,14 @@ function getPlatformInfo(userAgent) {
   };
 }
 
+export function isIOSWebKit(userAgent) {
+  const ua = getUserAgent(userAgent);
+  if (getPlatformInfo(ua).platform === 'ios') return true;
+  if (isIPad(ua)) return true;
+  if (typeof navigator === 'undefined') return false;
+  return ua.includes('Mac') && navigator.maxTouchPoints > 1;
+}
+
 export default function isDesktop(userAgent) {
   const ua = getUserAgent(userAgent);
   if (isHeadlessBrowser(ua)) return true;

--- a/unitylibs/utils/device-detection.js
+++ b/unitylibs/utils/device-detection.js
@@ -110,6 +110,11 @@ export function isIOS(userAgent) {
   return isIPad(ua) || getPlatformInfo(ua).platform === 'ios';
 }
 
+export function isIOSSafari(userAgent) {
+  const ua = getUserAgent(userAgent);
+  return isIOS(ua) && !/CriOS|FxiOS|OPiOS|EdgiOS/.test(ua);
+}
+
 export default function isDesktop(userAgent) {
   const ua = getUserAgent(userAgent);
   if (isHeadlessBrowser(ua)) return true;

--- a/unitylibs/utils/device-detection.js
+++ b/unitylibs/utils/device-detection.js
@@ -105,6 +105,11 @@ function getPlatformInfo(userAgent) {
   };
 }
 
+export function isIOS(userAgent) {
+  const ua = getUserAgent(userAgent);
+  return isIPad(ua) || getPlatformInfo(ua).platform === 'ios';
+}
+
 export default function isDesktop(userAgent) {
   const ua = getUserAgent(userAgent);
   if (isHeadlessBrowser(ua)) return true;


### PR DESCRIPTION
Ipad and tablets should follow mobile logic
 I've checked the Express RBG Experience; here's what I'm seeing: 

    On iOs/Safari first time user download scenario: For me it is only triggering the download and not redirecting to FF at all. I'm seeing the same thing unfortunately. 
    On iOS/chrome: Downloads the file and redirects to FF in same tab. This is correct, and what I see as well on Express (except they try to go to the app, we should go straight into Firefly)! 

Fallback for ios/safari if we are not able to achive download + redirect: 
1. "Only download and not redirect as Express does." Let's go with this fallback, because at least the user also sees "Open in Firefly" as a CTA on mobile, right? 
2. "Only redirect as user can still have a chance to download on product." Not Ideal User Journey as download is not as obvious in product

Resolves: [MWPW-198610](https://jira.corp.adobe.com/browse/MWPW-198610)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.live/drafts/vipulg/doodlebug/rbg/vg-rbg?unitylibs=stage
- After: https://main--da-cc--adobecom.aem.live/drafts/vipulg/doodlebug/rbg/vg-rbg?unitylibs=iosFix
