### PR TITLE
MWPW-190444 Remove image dimension restriction for firefly

### DIFF
--- a/unitylibs/core/workflow/workflow-upload/action-binder.js
+++ b/unitylibs/core/workflow/workflow-upload/action-binder.js
@@ -253,7 +253,7 @@ export default class ActionBinder {
           });
           throw error;
         }
-        await uploadHandler.scanImgForSafetyWithRetry(this.assetId, signal);        
+        await uploadHandler.scanImgForSafetyWithRetry(this.assetId, signal);
         const { createChunkAnalyticsData } = await import(`${getUnityLibs()}/utils/chunkingUtils.js`);
         const totalChunks = Math.ceil(file.size / blocksize);
         this.logAnalyticsinSplunk(
@@ -402,15 +402,9 @@ export default class ActionBinder {
     try {
       ({ width, height } = await getImageDimensions(file));
     } catch (e) { return null; }
-    const isMaxLimits = this.limits.maxWidth && this.limits.maxHeight;
-    const isMinLimits = this.limits.minWidth && this.limits.minHeight;
     this.filesData = { ...this.filesData, width, height };
-    if (isMaxLimits && (width > this.limits.maxWidth || height > this.limits.maxHeight)) {
+    if (this.limits.maxWidth && this.limits.maxHeight && (width > this.limits.maxWidth || height > this.limits.maxHeight)) {
       this.handleClientUploadError('.icon-error-filedimension', 'error-filedimension', 'Unable to process the file type!');
-      throw new Error('Unable to process the file type!');
-    }
-    if (isMinLimits && (width < this.limits.minWidth || height < this.limits.minHeight)) {
-      this.handleClientUploadError('.icon-error-filemindimension', 'error-filemindimension', 'Unable to process the file type!');
       throw new Error('Unable to process the file type!');
     }
     return { width, height };

--- a/unitylibs/core/workflow/workflow-upload/target-config.json
+++ b/unitylibs/core/workflow/workflow-upload/target-config.json
@@ -24,9 +24,7 @@
     },
     "limits-firefly": {
       "allowedFileTypes": ["image/jpeg", "image/png", "image/jpg", "image/webp"],
-      "maxFileSize": 100000000,
-      "minHeight": 512,
-      "minWidth": 512
+      "maxFileSize": 100000000
     },
     "limits-upload-video": {
       "allowedFileTypes": ["video/mp4", "video/quicktime"],


### PR DESCRIPTION
* Remove the 512x512 min dimension restriction for firefly to match in-product experience

Resolves: [MWPW-190444](https://jira.corp.adobe.com/browse/MWPW-190444)

**Testing Details**

*Happy Path*
- Visit https://stage--da-cc--adobecom.aem.page/products/firefly/features/sticker-generator?unitylibs=MWPW-190444 and upload an image smaller than 512x512 dimensions
- Verify that you do not get an error toast and the upload actually occurs and you are redirected to product

*Validate existing experiences with dimension checks*
- Visit https://stage--da-cc--adobecom.aem.page/products/photoshop-lightroom?unitylibs=MWPW-190444
- Upload an image that is greater than 8k resolution and verify that the error toast appears as expected

**Test URLs:**
- Before: https://stage--da-cc--adobecom.aem.page/products/firefly/features/sticker-generator?unitylibs=stage
- After: https://stage--da-cc--adobecom.aem.page/products/firefly/features/sticker-generator?unitylibs=MWPW-190444
