### PR TITLE
[MWPW-198790] Download CTA not appearing above the fold post-upload in Mobile

### DIFF
--- a/unitylibs/core/widgets/inline-action/inline-action.css
+++ b/unitylibs/core/widgets/inline-action/inline-action.css
@@ -922,12 +922,17 @@
     padding-bottom: 48px;
   }
 
+  .ia-widget[data-state="complete"] {
+    flex-direction: column-reverse;
+  }
+
   .ia-widget[data-state="complete"] .ia-complete {
     margin-top: 0;
     margin-right: 0;
+    margin-bottom: 0;
   }
 
-  .ia-widget[data-state="complete"] .ia-nba-heading { margin-top: 0; }
+  .ia-widget[data-state="complete"] .ia-nba-heading { margin-top: 16px; }
 
   .ia-nba-grid {
     display: flex;

--- a/unitylibs/core/widgets/inline-action/inline-action.css
+++ b/unitylibs/core/widgets/inline-action/inline-action.css
@@ -922,6 +922,10 @@
     padding-bottom: 48px;
   }
 
+  .ia-widget[data-state="loading"] .ia-panel-left {
+    display: none;
+  }
+
   .ia-widget[data-state="complete"] {
     flex-direction: column-reverse;
   }


### PR DESCRIPTION
[MWPW-198790] Download CTA not appearing above the fold post-upload in Mobile
designs : https://www.figma.com/design/w2VbLPROC36BO0DA0wBgyY?node-id=19581-28680&m=dev#1806843368

Resolves: [MWPW-198790](https://jira.corp.adobe.com/browse/MWPW-198790)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/firefly/features/remove-background?unitylibs=stage
- After: https://main--da-cc--adobecom.aem.page/products/firefly/features/remove-background?unitylibs=mwpw-198790
https://main--da-cc--adobecom.aem.live/drafts/vipulg/doodlebug/rbg/vg-rbg?unitylibs=mwpw-198790
