### PR TITLE
[MWPW-198862] disable right click download on removed bg image

### DIFF
--- a/unitylibs/core/widgets/inline-action/inline-action.css
+++ b/unitylibs/core/widgets/inline-action/inline-action.css
@@ -238,6 +238,8 @@
   max-height: 320px;
   overflow: hidden;
   box-sizing: border-box;
+  -webkit-touch-callout: none;
+  user-select: none;
 }
 
 .ia-checker {
@@ -263,6 +265,8 @@
   max-height: 100%;
   object-fit: contain;
   flex: 0 1 auto;
+  -webkit-user-drag: none;
+  user-select: none;
   background:
     linear-gradient(45deg, #ccc 25%, transparent 25%),
     linear-gradient(-45deg, #ccc 25%, transparent 25%),

--- a/unitylibs/core/widgets/inline-action/inline-action.js
+++ b/unitylibs/core/widgets/inline-action/inline-action.js
@@ -338,11 +338,13 @@ function buildCompletePanel(meta) {
 }
 
 function buildResultSection(meta) {
-  const checker = createTag('div', { class: 'ia-checker' }, createTag('img', {
+  const img = createTag('img', {
     class: 'ia-result-img',
     src: '',
     alt: 'Processed image',
-  }));
+    draggable: 'false',
+  });
+  const checker = createTag('div', { class: 'ia-checker' }, img);
   const resultActions = createTag('div', { class: 'ia-result-actions' });
   const reuploadBtn = createTag('button', {
     type: 'button',
@@ -360,7 +362,9 @@ function buildResultSection(meta) {
   downloadBtn.append(createTag('span', {}, meta.downloadLabel));
   resultActions.append(reuploadBtn, downloadBtn);
   checker.append(resultActions);
-  return createTag('div', { class: 'ia-result' }, checker);
+  const result = createTag('div', { class: 'ia-result' }, checker);
+  result.addEventListener('contextmenu', (e) => { e.preventDefault(); });
+  return result;
 }
 
 function buildLeftPanel(heroPreview, meta) {


### PR DESCRIPTION
[MWPW-198862] disable right click download on removed bg image

Resolves: [MWPW-198862](https://jira.corp.adobe.com/browse/MWPW-198862)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/firefly/features/remove-background?unitylibs=stage
- After: https://main--da-cc--adobecom.aem.page/products/firefly/features/remove-background?unitylibs=mwpw-198862
https://main--da-cc--adobecom.aem.live/drafts/vipulg/doodlebug/rbg/vg-rbg?unitylibs=mwpw-198862
