### PR TITLE
[MWPW-198728] have diffenent css for loading state after complete state

### DIFF
--- a/unitylibs/core/widgets/inline-action/inline-action.css
+++ b/unitylibs/core/widgets/inline-action/inline-action.css
@@ -360,6 +360,10 @@
   grid-area: dropzone-shell;
 }
 
+.unity-inline-action .ia-widget[data-state="loading"] .drop-zone-container.ia-dropzone-shell.ia-from-complete {
+  margin: 80px 0 0;
+}
+
 .unity-inline-action .drop-zone {
   border: var(--ia-drop-zone-border);
   border-radius: var(--ia-radius-sm);
@@ -869,6 +873,12 @@
     max-height: 194px;
   }
 
+  .ia-widget[data-state="loading"][data-loading-layout="complete"] .ia-ghost {
+    height: 281px;
+    min-height: 281px;
+    max-height: 281px;
+  }
+
   .ia-widget[data-state="initial"] .ia-preview :is(picture, picture > img, video) {
     width: 100%;
     height: 100%;
@@ -923,6 +933,10 @@
   }
 
   .ia-widget[data-state="complete"] {
+    flex-direction: column-reverse;
+  }
+
+  .ia-widget[data-state="loading"][data-loading-layout="complete"] {
     flex-direction: column-reverse;
   }
 
@@ -1000,6 +1014,12 @@
     height: 368px;
     min-height: 368px;
     max-height: 368px;
+  }
+
+  .ia-widget[data-state="loading"][data-loading-layout="complete"] {
+    height: 500px;
+    min-height: 500px;
+    max-height: 500px;
   }
 
   .ia-widget[data-state="complete"] {

--- a/unitylibs/core/widgets/inline-action/inline-action.css
+++ b/unitylibs/core/widgets/inline-action/inline-action.css
@@ -922,12 +922,17 @@
     padding-bottom: 48px;
   }
 
+  .ia-widget[data-state="complete"] {
+    flex-direction: column-reverse;
+  }
+
   .ia-widget[data-state="complete"] .ia-complete {
     margin-top: 0;
     margin-right: 0;
+    margin-bottom: 0;
   }
 
-  .ia-widget[data-state="complete"] .ia-nba-heading { margin-top: 0; }
+  .ia-widget[data-state="complete"] .ia-nba-heading { margin-top: 16px; }
 
   .ia-nba-grid {
     display: flex;

--- a/unitylibs/core/widgets/inline-action/inline-action.js
+++ b/unitylibs/core/widgets/inline-action/inline-action.js
@@ -410,8 +410,17 @@ export default class InlineActionWidget {
   }
 
   setState(state) {
+    const prev = this.state;
     this.state = state;
-    if (this.widget) this.widget.dataset.state = state;
+    if (!this.widget) return;
+    this.widget.dataset.state = state;
+    if (state === InlineActionState.LOADING && prev === InlineActionState.COMPLETE) {
+      this.widget.dataset.loadingLayout = 'complete';
+      this.widget.querySelector('.ia-dropzone-shell')?.classList.add('ia-from-complete');
+    } else {
+      delete this.widget.dataset.loadingLayout;
+      this.widget.querySelector('.ia-dropzone-shell')?.classList.remove('ia-from-complete');
+    }
   }
 
   setProgress(pct) {


### PR DESCRIPTION
fix to have different css for loading state after complete state
design : https://www.figma.com/design/w2VbLPROC36BO0DA0wBgyY?node-id=12088-39554&m=dev#1807009397
Resolves: [MWPW-198728](https://jira.corp.adobe.com/browse/MWPW-198728)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/firefly/features/remove-background?unitylibs=stage
- After: https://main--da-cc--adobecom.aem.page/products/firefly/features/remove-background?unitylibs=mwpw-198728
