### PR TITLE
[MWPW-198934] Fix .ai upload failing due to incorrect browser MIME type

### DIFF
--- a/test/core/workflow/workflow-acrobat/action-binder.test.js
+++ b/test/core/workflow/workflow-acrobat/action-binder.test.js
@@ -1355,6 +1355,27 @@ describe('ActionBinder', () => {
         expect(actionBinder.handleSingleFileUpload.called).to.be.false;
       });
 
+      it('should normalize proprietary Adobe formats (.ai) to the canonical MIME when the browser reports a wrong type', async () => {
+        const files = [{ name: 'art.ai', type: 'application/postscript', size: 1048576 }];
+        await actionBinder.handleFileUpload(files);
+        const validatedFiles = actionBinder.validateFiles.firstCall.args[0];
+        expect(validatedFiles[0].type).to.equal('application/illustrator');
+      });
+
+      it('should normalize proprietary Adobe formats (.psd) to the canonical MIME when the browser reports no type', async () => {
+        const files = [{ name: 'design.psd', type: '', size: 1048576 }];
+        await actionBinder.handleFileUpload(files);
+        const validatedFiles = actionBinder.validateFiles.firstCall.args[0];
+        expect(validatedFiles[0].type).to.equal('image/vnd.adobe.photoshop');
+      });
+
+      it('should keep the browser-reported MIME for non-proprietary formats', async () => {
+        const files = [{ name: 'photo.jpg', type: 'image/jpeg', size: 1048576 }];
+        await actionBinder.handleFileUpload(files);
+        const validatedFiles = actionBinder.validateFiles.firstCall.args[0];
+        expect(validatedFiles[0].type).to.equal('image/jpeg');
+      });
+
       it('should handle single file from multi-file upload when validation fails for others', async () => {
         const files = [
           { name: 'test1.pdf', type: 'application/pdf', size: 1048576 },

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -627,7 +627,7 @@ export default class ActionBinder {
     const verbsWithoutFallback = this.workflowCfg.targetCfg.verbsWithoutMfuToSfuFallback;
     const sanitizedFiles = await Promise.all(files.map(async (file) => {
       const sanitizedFileName = await this.sanitizeFileName(file.name);
-      const mimeType = file.type || await this.getMimeType(file);
+      const mimeType = (await this.getMimeType(file)) || file.type;
       return new File([file], sanitizedFileName, { type: mimeType, lastModified: file.lastModified });
     }));
     this.MULTI_FILE = files.length > 1;


### PR DESCRIPTION
## Description
Fixes the blocker where uploading `.ai` files fails validation with "This file is in a format not supported for conversion to PDF" (MWPW-198934). Affects any verb that accepts these formats, not just the new ones.

**Root cause:** In `handleFileUpload`, the MIME was derived as `file.type || getMimeType(file)`. Browsers report `.ai` as `application/postscript` (wrong, non-empty), so the `||` keeps it and skips the canonical-MIME fallback → not in `allowedFileTypes` → rejected. (`.indd` reports empty → fallback rescues it; `.psd` reports the correct type → both already worked.)

**Fix:** Flip the precedence to `(await this.getMimeType(file)) || file.type` so the extension-derived canonical MIME wins for the proprietary formats `getMimeType` maps (`.ai`, `.psd`, `.indd`, `.form`). All other extensions are unaffected. Also ensures the correct `format` is sent to createAsset/connector. Added tests for `.ai`, `.psd`, and `.jpg`.

> Confirmed separately with BE (@nemahaja) that the `jpg-to-pdf` conversion path accepts AI/PSD/INDD as inputs.

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-198934](https://jira.corp.adobe.com/browse/MWPW-198934)
## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.page/acrobat/online/test/ai-to-pdf?unitylibs=mwpw-198934-upload-ai-images
- https://stage--da-dc--adobecom.aem.page/acrobat/online/test/psd-to-pdf?unitylibs=mwpw-198934-upload-ai-images
- https://stage--da-dc--adobecom.aem.page/acrobat/online/test/indd-to-pdf?unitylibs=mwpw-198934-upload-ai-images
- https://stage--da-dc--adobecom.aem.page/acrobat/online/test/jpg-to-pdf?unitylibs=mwpw-198934-upload-ai-images
