### PR TITLE
[AEEE-35854][MWPW-199140] Firefly Logo on transition screen for express url

### DIFF
--- a/unitylibs/scripts/transition-screen.js
+++ b/unitylibs/scripts/transition-screen.js
@@ -96,19 +96,22 @@ export default class TransitionScreen {
     return splashScreenConfig.fragmentLink;
   }
 
-  replaceDotMedia(area = document) {
+  replaceDotMedia(area = document, fragmentBaseUrl = null) {
     const config = getConfig?.();
     const contentRoot = config?.contentRoot ?? '';
-    if (!contentRoot) return;
+    if (!fragmentBaseUrl && !contentRoot) return;
     const prefix = (config?.locale?.prefix ?? '').replace('/', '') ?? '';
     const currUrl = new URL(window.location.href);
     const pathSeg = currUrl.pathname.split('/').length;
-    if (area === document && ((prefix === '' && pathSeg >= 3) || (prefix !== '' && pathSeg >= 4))) return;
+    if (!fragmentBaseUrl && area === document && ((prefix === '' && pathSeg >= 3) || (prefix !== '' && pathSeg >= 4))) return;
     const resetAttributeBase = (tag, attr) => {
       area.querySelectorAll(`${tag}[${attr}^="./media_"]`).forEach((el) => {
         const value = el.getAttribute(attr);
         if (!value) return;
-        el.setAttribute(attr, new URL(`${contentRoot}${value.substring(1)}`, window.location.href).href);
+        const resolvedUrl = fragmentBaseUrl
+          ? new URL(value, fragmentBaseUrl).href
+          : new URL(`${contentRoot}${value.substring(1)}`, window.location.href).href;
+        el.setAttribute(attr, resolvedUrl);
       });
     };
     resetAttributeBase('img', 'src');
@@ -138,7 +141,8 @@ export default class TransitionScreen {
     const sections = doc.querySelectorAll('body > div');
     const f = createTag('div', { class: 'fragment splash-loader decorate', style: 'display: none', tabindex: '-1', role: 'dialog', 'aria-modal': 'true' });
     if (this.workflowCfg.theme === 'dark') f.classList.add('dark');
-    if (getMatchedDomain(this.workflowCfg.targetCfg.domainMap) === 'acrobat') sections.forEach(sec => this.replaceDotMedia(sec))
+    const fragmentBaseUrl = new URL(`${this.splashFragmentLink}.plain.html`, window.location.href).href;
+    sections.forEach((sec) => this.replaceDotMedia(sec, fragmentBaseUrl));
     f.append(...sections);
     const splashDiv = document.querySelector(
       this.workflowCfg.targetCfg.splashScreenConfig.splashScreenParent,


### PR DESCRIPTION
Fix for correctly loading the media on the Transition screen.

What the old code did
The old code only ran replaceDotMedia for Acrobat, and resolved media paths using contentRoot from the current page's config.
Instead of using contentRoot, we construct the base URL from where the fragment is actually fetched and then resolve each ./media_* relative to that.
This is correct for every domain — Firefly, Acrobat, Express — because the media always lives next to the fragment, regardless of what contentRoot is or which page loads the fragment.

Resolves: 
[AEEE-35854](https://jira.corp.adobe.com/browse/AEEE-35854)
[MWPW-199140](https://jira.corp.adobe.com/browse/MWPW-199140)

For Validation use below URL:
https://www.adobe.com/express/feature/image/remove-background?at_preview_token=lLr7bJrDlMCVKw90nSqAxA&at_preview_index=1_2&at_preview_listed_activities_only=true&at_preview_evaluate_as_true_audience_ids=2515310
and replace the transition-screen.js file with the new file content.

**Test URLs:**
- Before: https://main--unity--adobecom.aem.page/?martech=off
- After: https://<branch>--unity--adobecom.aem.page/?martech=off
