### PR TITLE
[MWPW-198657]add direct upload support to more convert verbs

### DIFF
--- a/unitylibs/core/workflow/workflow-acrobat/target-config.json
+++ b/unitylibs/core/workflow/workflow-acrobat/target-config.json
@@ -15,7 +15,7 @@
     "sendSplunkAnalytics": true,
     "verbsWithoutMfuToSfuFallback": ["compress-pdf"],
     "awaitFinalizeVerbs": ["word-to-pdf"],
-    "directUploadVerbs": ["word-to-pdf"],
+    "directUploadVerbs": ["word-to-pdf", "ppt-to-pdf", "excel-to-pdf", "jpg-to-pdf", "png-to-pdf", "heic-to-pdf"],
     "directUploadMaxSize": 1048576,
     "nonpdfMfuFeedbackScreenTypeNonpdf": ["combine-pdf"],
     "nonpdfSfuProductScreen": ["word-to-pdf", "jpg-to-pdf", "ppt-to-pdf", "excel-to-pdf", "png-to-pdf", "createpdf", "chat-pdf", "chat-pdf-student", "summarize-pdf", "pdf-ai", "heic-to-pdf", "image-to-pdf", "bmp-to-pdf", "gif-to-pdf", "tiff-to-pdf", "indd-to-pdf", "psd-to-pdf", "ai-to-pdf", "quiz-maker", "flashcard-maker", "mindmap-maker", "resume-builder"],


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* add direct upload support to more convert verbs

Resolves: [MWPW-198657](https://jira.corp.adobe.com/browse/MWPW-198657)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.live/acrobat/online/jpg-to-pdf?martech=off&unitylibs=stage
- After: https://main--da-dc--adobecom.aem.live/acrobat/online/jpg-to-pdf?martech=off&unitylibs=MWPW-198657

- Before: https://main--da-dc--adobecom.aem.live/acrobat/online/png-to-pdf?martech=off&unitylibs=stage
- After: https://main--da-dc--adobecom.aem.live/acrobat/online/png-to-pdf?martech=off&unitylibs=MWPW-198657

- Before: https://main--da-dc--adobecom.aem.live/acrobat/online/ppt-to-pdf?martech=off&unitylibs=stage
- After: https://main--da-dc--adobecom.aem.live/acrobat/online/ppt-to-pdf?martech=off&unitylibs=MWPW-198657

- Before: https://main--da-dc--adobecom.aem.live/acrobat/online/excel-to-pdf?martech=off&unitylibs=stage
- After: https://main--da-dc--adobecom.aem.live/acrobat/online/excel-to-pdf?martech=off&unitylibs=MWPW-198657

- Before: https://main--dc-frictionless--adobecom.aem.live/heic-to-pdf?martech=off&unitylibs=stage
- After: https://main--dc-frictionless--adobecom.aem.live/heic-to-pdf?martech=off&unitylibs=MWPW-198657

## Testing Notes

**Change:** Added `ppt-to-pdf`, `excel-to-pdf`, `jpg-to-pdf`, `png-to-pdf`, and `heic-to-pdf` to `directUploadVerbs` in `target-config.json`. Files ≤ 1 MB on these verbs now use the single-step `POST /asset/upload` direct upload path instead of the create-asset → chunk → finalize chain.

---

### For each verb (`ppt-to-pdf`, `excel-to-pdf`, `jpg-to-pdf`, `png-to-pdf`, `heic-to-pdf`)

**Small file (≤ 1 MB) — direct upload path (new behavior)**
- [ ] Upload a valid file under 1 MB
- [ ] Verify the upload completes and redirects to Acrobat successfully
- [ ] Verify no finalize/polling step occurs (should be faster than before)
- [ ] Verify the converted PDF opens correctly in Acrobat

**Large file (> 1 MB) — standard chunked path (unchanged behavior)**
- [ ] Upload a valid file over 1 MB
- [ ] Verify the upload follows the standard create-asset → chunk → finalize flow
- [ ] Verify redirect to Acrobat and PDF opens correctly
- [ ] Confirm no direct upload endpoint is called for large files

---

### Regression: `word-to-pdf` (must be unaffected)
- [ ] Small file (≤ 1 MB, `.doc` or `.docx`): direct upload path still works
- [ ] Large file (> 1 MB, `.doc` or `.docx`): chunked path with finalize-await still works

### Regression: other verbs (`compress-pdf`, `pdf-to-word`, etc.)
- [ ] Verify upload and redirect behavior is unchanged for verbs not in `directUploadVerbs`

---
