### PR TITLE
[MWPW-199315] Set file input accept attribute on feedback screen upload

### DIFF
--- a/test/core/workflow/workflow-acrobat/action-binder.test.js
+++ b/test/core/workflow/workflow-acrobat/action-binder.test.js
@@ -1719,6 +1719,30 @@ describe('ActionBinder', () => {
         extractSpy.restore();
       });
 
+      it('should set accept attribute on input when allowedFileTypes is populated', async () => {
+        const el = document.createElement('input');
+        el.type = 'file';
+        const block = { querySelector: sinon.stub().returns(el) };
+        const actMap = { input: 'upload' };
+        actionBinder.limits = { allowedFileTypes: ['application/illustrator', 'application/x-indesign'] };
+
+        await actionBinder.initActionListeners(block, actMap);
+
+        expect(el.getAttribute('accept')).to.equal('application/illustrator,application/x-indesign');
+      });
+
+      it('should not set accept attribute on input when allowedFileTypes is empty', async () => {
+        const el = document.createElement('input');
+        el.type = 'file';
+        const block = { querySelector: sinon.stub().returns(el) };
+        const actMap = { input: 'upload' };
+        actionBinder.limits = { allowedFileTypes: [] };
+
+        await actionBinder.initActionListeners(block, actMap);
+
+        expect(el.getAttribute('accept')).to.be.null;
+      });
+
       it('should handle input change event with multiple files', async () => {
         const el = document.createElement('input');
         el.type = 'file';

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -879,6 +879,9 @@ export default class ActionBinder {
           break;
         }
         case el.nodeName === 'INPUT':
+          if (this.limits.allowedFileTypes?.length) {
+            el.setAttribute('accept', this.limits.allowedFileTypes.join(','));
+          }
           el.addEventListener('change', async (e) => {
             const { files, totalFileSize } = this.extractFiles(e);
             await this.acrobatActionMaps(value, files, totalFileSize, 'change');


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Set `accept` attribute on the file input when `initActionListeners` is called for the acrobat feedback screen, so the browser file picker shows verb-specific file types (e.g. `.ai`, `.indd`) instead of filtering on the hardcoded `application/pdf`

Resolves: [MWPW-196472](https://jira.corp.adobe.com/browse/MWPW-196472)

**Test URLs:**
https://main--da-dc--adobecom.aem.page/acrobat/online/ai-to-pdf?unitylibs=MWPW-199315
