### PR TITLE
fix for correctly tracking splunk analytics

### DIFF
--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -115,7 +115,7 @@ export default class ActionBinder {
     sendAnalyticsEvent(new CustomEvent(eventName, {
       detail: { workflow: metaData.workflow },
     }));
-    this.logAnalyticsinSplunk(eventName, data);
+    return this.logAnalyticsinSplunk(eventName, data);
   }
 
   trackRemoveBackgroundError(error) {
@@ -152,7 +152,7 @@ export default class ActionBinder {
   }
 
   trackConnectorSuccess(verb, assetId) {
-    this.trackEvent(INLINE_ACTION_EVENTS.CONNECTOR_SUCCESS, {
+    return this.trackEvent(INLINE_ACTION_EVENTS.CONNECTOR_SUCCESS, {
       assetId: assetId || this.resultAssetId,
       verb,
       fileMetaData: this.filesData,
@@ -208,7 +208,7 @@ export default class ActionBinder {
   }
 
   logAnalyticsinSplunk(eventName, data) {
-    this.sendAnalyticsToSplunk?.(
+    return this.sendAnalyticsToSplunk?.(
       eventName,
       this.workflowCfg.productName,
       this.getAnalyticsMeta(data),
@@ -477,8 +477,9 @@ export default class ActionBinder {
         error.status = res?.status;
         throw error;
       }
-      this.trackConnectorSuccess(cOpts.payload?.verb, cOpts.assetId);
+      const trackSuccessPromise = this.trackConnectorSuccess(cOpts.payload?.verb, cOpts.assetId);
       if (openInSameTab) {
+        await trackSuccessPromise;
         if (useSplashProgress && this.transitionScreen?.splashScreenEl) {
           this.transitionScreen.LOADER_LIMIT = PROGRESS.COMPLETE;
           this.setProgress(PROGRESS.COMPLETE, true);
@@ -487,7 +488,10 @@ export default class ActionBinder {
         return res;
       }
       const opened = window.open(res.url, '_blank');
-      if (!opened) window.location.href = res.url;
+      if (!opened) {
+        await trackSuccessPromise;
+        window.location.href = res.url;
+      }
       return res;
     } catch (e) {
       if (e.name !== 'AbortError') {

--- a/unitylibs/scripts/analytics.js
+++ b/unitylibs/scripts/analytics.js
@@ -103,8 +103,8 @@ function createPayloadForSplunk(metaData) {
 export default function sendAnalyticsToSplunk(eventName, product, metaData, splunkEndpoint, sendBeacon = false) {
   try {
     const eventDataPayload = createPayloadForSplunk({ ...metaData, eventName, product });
-    if (sendBeacon && navigator.sendBeacon && navigator.sendBeacon(splunkEndpoint, JSON.stringify(eventDataPayload))) return;
-    fetch(splunkEndpoint, {
+    if (sendBeacon && navigator.sendBeacon && navigator.sendBeacon(splunkEndpoint, JSON.stringify(eventDataPayload))) return Promise.resolve();
+    return fetch(splunkEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(eventDataPayload),
@@ -114,5 +114,6 @@ export default function sendAnalyticsToSplunk(eventName, product, metaData, splu
       `An error occurred while sending ${eventName} to splunk, metadata: ${JSON.stringify(metaData || {})}, error: ${error || ''}`,
       { sampleRate: 100, tags: 'Unity-PS-Upload' },
     );
+    return Promise.resolve();
   }
 }


### PR DESCRIPTION
fix: await connector success analytics before same-tab redirect

Connector success analytics were being lost on same-tab redirects because window.location.href unloaded the page before the in-flight Splunk fetch could complete.

Threaded the Promise return value up through sendAnalyticsToSplunk → logAnalyticsinSplunk → trackEvent → trackConnectorSuccess and awaited it in callConnector only on same-tab redirect paths — both openInSameTab and the popup-blocked window.open fallback. New-tab redirects do not await since the current page stays alive and the fetch completes naturally.

The change to analytics.js is additive — all other callers across workflows are already discarding the return value and are unaffected.

This PR needs validation across workflows and across different products.

Resolves: [MWPW-199504](https://jira.corp.adobe.com/browse/MWPW-199504)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/firefly/features/remove-background
- After: https://main--da-cc--adobecom.aem.page/products/firefly/features/remove-background?unitylibs=splunkFix
