### PR TITLE
MWPW-199518 Adding workaround for image aspect ratio distortion

### DIFF
--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -22,6 +22,28 @@ const UPLOAD_ERROR_TYPE = '.icon-error-request';
 const PROGRESS = { UPLOAD_MAX: 60, REMOVE_BG: 95, COMPLETE: 100 };
 const getMount = (el) => el?.querySelector?.('.ia-widget') || el;
 
+function correctOrientation(file) {
+  if (!file.type.match(/image\/(jpeg|jpg)/i)) return Promise.resolve(file);
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      canvas.getContext('2d').drawImage(img, 0, 0);
+      canvas.toBlob(
+        (blob) => resolve(blob ? new File([blob], file.name, { type: file.type }) : file),
+        file.type,
+        0.92,
+      );
+    };
+    img.onerror = () => { URL.revokeObjectURL(url); resolve(file); };
+    img.src = url;
+  });
+}
+
 class ServiceHandler {
   constructor(canvasArea, unityEl, getAdditionalHeaders) {
     this.canvasArea = canvasArea;
@@ -613,17 +635,18 @@ export default class ActionBinder {
   async uploadFile(files) {
     const file = await this.validateFile(files);
     if (!file) return;
+    const correctedFile = await correctOrientation(file);
     this.uploadAbortController = null;
     this.assetId = null;
     this.resultAssetId = null;
     this.resultUrl = null;
     this.resultBlob = null;
-    this.filesData = { count: 1, size: file.size, type: file.type, name: file.name };
+    this.filesData = { count: 1, size: correctedFile.size, type: correctedFile.type, name: correctedFile.name };
     const { isGuest } = await isGuestUser();
     this.isGuestUser = isGuest;
     this.trackEvent('Uploading Started|UnityWidget');
-    if (isGuest === false) await this.signedInFlow(file);
-    else await this.anonymousFlow(file);
+    if (isGuest === false) await this.signedInFlow(correctedFile);
+    else await this.anonymousFlow(correctedFile);
   }
 
   async runFirstLocalDownload() {

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -22,8 +22,40 @@ const UPLOAD_ERROR_TYPE = '.icon-error-request';
 const PROGRESS = { UPLOAD_MAX: 60, REMOVE_BG: 95, COMPLETE: 100 };
 const getMount = (el) => el?.querySelector?.('.ia-widget') || el;
 
-function correctOrientation(file) {
-  if (!file.type.match(/image\/(jpeg|jpg)/i)) return Promise.resolve(file);
+async function readExifOrientation(file) {
+  const buffer = await file.slice(0, 64 * 1024).arrayBuffer();
+  const view = new DataView(buffer);
+  if (view.getUint16(0) !== 0xFFD8) return null;
+  let offset = 2;
+  while (offset < view.byteLength - 4) {
+    const marker = view.getUint16(offset);
+    const segmentLength = view.getUint16(offset + 2);
+    if (marker === 0xFFE1) {
+      if (view.getUint32(offset + 4) !== 0x45786966) return null;
+      const tiffOffset = offset + 10;
+      const little = view.getUint16(tiffOffset) === 0x4949;
+      const ifdOffset = view.getUint32(tiffOffset + 4, little);
+      const entries = view.getUint16(tiffOffset + ifdOffset, little);
+      for (let i = 0; i < entries; i += 1) {
+        const entryOffset = tiffOffset + ifdOffset + 2 + (i * 12);
+        if (view.getUint16(entryOffset, little) === 0x0112) {
+          return view.getUint16(entryOffset + 8, little);
+        }
+      }
+      return null;
+    }
+    if ((marker & 0xFF00) !== 0xFF00) break;
+    offset += 2 + segmentLength;
+  }
+  return null;
+}
+
+async function correctOrientation(file) {
+  if (!file.type.match(/image\/(jpeg|jpg)/i)) return file;
+  const { default: isDesktop } = await import(`${getUnityLibs()}/utils/device-detection.js`);
+  if (isDesktop()) return file;
+  const orientation = await readExifOrientation(file);
+  if (!orientation || orientation === 1) return file;
   return new Promise((resolve) => {
     const url = URL.createObjectURL(file);
     const img = new Image();

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -51,10 +51,10 @@ async function readExifOrientation(file) {
 }
 
 async function correctOrientation(file) {
-  if (!file.type.match(/image\/(jpeg|jpg)/i)) return file;
+  if (!/image\/(jpeg|jpg)/i.test(file.type)) return file;
   const { default: isDesktop } = await import(`${getUnityLibs()}/utils/device-detection.js`);
   if (isDesktop()) return file;
-  const orientation = await readExifOrientation(file);
+  const orientation = await readExifOrientation(file).catch(() => null);
   if (!orientation || orientation === 1) return file;
   return new Promise((resolve) => {
     const url = URL.createObjectURL(file);

--- a/unitylibs/core/workflow/workflow-inline-action/action-binder.js
+++ b/unitylibs/core/workflow/workflow-inline-action/action-binder.js
@@ -52,8 +52,6 @@ async function readExifOrientation(file) {
 
 async function correctOrientation(file) {
   if (!/image\/(jpeg|jpg)/i.test(file.type)) return file;
-  const { default: isDesktop } = await import(`${getUnityLibs()}/utils/device-detection.js`);
-  if (isDesktop()) return file;
   const orientation = await readExifOrientation(file).catch(() => null);
   if (!orientation || orientation === 1) return file;
   return new Promise((resolve) => {


### PR DESCRIPTION
* Fix distorted aspect ratio on Remove Background for iPhone portrait photos by correcting EXIF orientation before upload
* Add readExifOrientation to read the EXIF orientation tag from JPEG headers without loading the full image
* Add correctOrientation to redraw JPEG to canvas pre-upload, baking in correct pixel orientation for the RemoveBackground API
* Gate orientation correction to mobile only — desktop JPEGs are unaffected and incur no overhead
* Skip canvas re-encoding entirely if EXIF orientation is already correct (value 1), avoiding unnecessary processing for screenshots and pre-processed images

Resolves: [MWPW-199518](https://jira.corp.adobe.com/browse/MWPW-199518)

**Test URLs:**
- Before: https://stage--da-cc--adobecom.aem.live/products/firefly/features/remove-background?unitylibs=stage
- After: https://stage--da-cc--adobecom.aem.live/products/firefly/features/remove-background?unitylibs=MWPW-199518

**Testing Use Cases**
- Upload a recently taken iPhone portrait photo on adobe.com Remove Background page on iPhone Safari (iOS 18.x) and verify the result image is not distorted
- Upload the same photo on desktop browser and verify it processes correctly with no regression
- Upload a PNG and WebP file on iPhone Safari and verify they are unaffected by the change
- Upload a JPEG screenshot or downloaded image (no EXIF rotation) on iPhone Safari and verify the canvas re-encoding step is skipped (result should be identical to before)
- Upload a landscape iPhone photo and verify it processes correctly with no distortion
