### PR TITLE
[MWPW-199606]Fix intermittent issue of experiment data not fetched for A/B testing

### DIFF
--- a/test/core/workflow/workflow-acrobat/action-binder.test.js
+++ b/test/core/workflow/workflow-acrobat/action-binder.test.js
@@ -3037,4 +3037,122 @@ describe('ActionBinder', () => {
       expect(Array.isArray(result)).to.be.true;
     });
   });
+
+  describe('ensurePageConfig', () => {
+    let originalFetch;
+
+    const mockFetchResponse = (config = {}) => ({
+      ok: true,
+      json: async () => ({ location: 'https://test-location.com', config }),
+    });
+
+    const mockSatellite = (content = null) => {
+      window._satellite = {
+        track: (event, options) => {
+          if (typeof options.done === 'function') {
+            const result = content
+              ? { decisions: [{ items: [{ data: { content } }] }], propositions: [] }
+              : { decisions: [], propositions: [] };
+            setTimeout(() => options.done(result, null), 0);
+          }
+        },
+      };
+    };
+
+    beforeEach(() => {
+      originalFetch = window.fetch;
+      window.unityConfig.pageConfigEndPoint = 'https://test-api.adobe.com/pageconfig';
+      actionBinder.pageConfigFetched = false;
+      actionBinder.pageConfigPromise = null;
+      actionBinder.pageConfigLocation = null;
+      actionBinder.experimentData = null;
+      actionBinder.experimentViaPageConfig = false;
+      sinon.stub(actionBinder, 'dispatchErrorToast').resolves();
+    });
+
+    afterEach(() => {
+      window.fetch = originalFetch;
+      delete window._satellite;
+    });
+
+    it('should not run again when pageConfigFetched is already true', async () => {
+      actionBinder.pageConfigFetched = true;
+      window.fetch = sinon.stub();
+
+      await actionBinder.ensurePageConfig();
+
+      expect(window.fetch.called).to.be.false;
+    });
+
+    it('should reset pageConfigFetched and pageConfigPromise when getExperimentData fails on first attempt without dispatching error', async () => {
+      window.fetch = sinon.stub().resolves(mockFetchResponse({ target: { enabled: true, decisionScopes: ['scope1'] } }));
+      window._satellite = {
+        track: (event, options) => {
+          if (typeof options.done === 'function') setTimeout(() => options.done(null, new Error('Target error')), 0);
+        },
+      };
+
+      await actionBinder.ensurePageConfig();
+
+      expect(actionBinder.pageConfigFetched).to.be.false;
+      expect(actionBinder.pageConfigPromise).to.be.null;
+      expect(actionBinder.dispatchErrorToast.called).to.be.false;
+    });
+
+    it('should reset flags and dispatch error to Splunk when getExperimentData fails on retry', async () => {
+      actionBinder.pageConfigLocation = 'https://existing-location.com';
+      window.fetch = sinon.stub().resolves(mockFetchResponse({ target: { enabled: true, decisionScopes: ['scope1'] } }));
+      window._satellite = {
+        track: (event, options) => {
+          if (typeof options.done === 'function') setTimeout(() => options.done(null, new Error('Target error')), 0);
+        },
+      };
+
+      await actionBinder.ensurePageConfig();
+
+      expect(actionBinder.pageConfigFetched).to.be.false;
+      expect(actionBinder.pageConfigPromise).to.be.null;
+      expect(actionBinder.dispatchErrorToast.calledOnce).to.be.true;
+    });
+
+    it('should set experimentData and experimentViaPageConfig when pageConfig target is enabled', async () => {
+      const mockData = { variationId: 'variant-1' };
+      window.fetch = sinon.stub().resolves(mockFetchResponse({ target: { enabled: true, decisionScopes: ['scope1'] } }));
+      mockSatellite(mockData);
+
+      await actionBinder.ensurePageConfig();
+
+      expect(actionBinder.experimentData).to.deep.equal(mockData);
+      expect(actionBinder.experimentViaPageConfig).to.be.true;
+      expect(actionBinder.pageConfigFetched).to.be.true;
+    });
+
+    it('should set experimentData via targetCfg.experimentationOn when pageConfig target is not enabled', async () => {
+      const mockData = { variationId: 'variant-2' };
+      actionBinder.workflowCfg.enabledFeatures = ['compress-pdf'];
+      actionBinder.workflowCfg.targetCfg.experimentationOn = ['compress-pdf'];
+      window.fetch = sinon.stub()
+        .onFirstCall().resolves(mockFetchResponse({}))
+        .onSecondCall()
+        .resolves({ ok: true, json: async () => ({ country: 'US' }) });
+      mockSatellite(mockData);
+
+      await actionBinder.ensurePageConfig();
+
+      expect(actionBinder.experimentData).to.deep.equal(mockData);
+      expect(actionBinder.experimentViaPageConfig).to.be.false;
+      expect(actionBinder.pageConfigFetched).to.be.true;
+    });
+
+    it('should not call _satellite when pageConfig target is not enabled and verb not in experimentationOn', async () => {
+      window.fetch = sinon.stub().resolves(mockFetchResponse({}));
+      window._satellite = { track: sinon.stub() };
+
+      await actionBinder.ensurePageConfig();
+
+      expect(window._satellite.track.called).to.be.false;
+      expect(actionBinder.experimentData).to.be.null;
+      expect(actionBinder.pageConfigFetched).to.be.true;
+    });
+  });
 });

--- a/test/utils/experiment-provider.test.js
+++ b/test/utils/experiment-provider.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
 import getExperimentData, { getDecisionScopesForVerb } from '../../unitylibs/utils/experiment-provider.js';
 
 describe('getExperimentData', () => {
@@ -115,6 +116,40 @@ describe('getExperimentData', () => {
     setupMock(undefined);
     const result = await getExperimentData(['acom_unity_acrobat_add-comment_us']);
     expect(result).to.equal(null);
+  });
+});
+
+describe('waitForSatellite behavior in getExperimentData', () => {
+  afterEach(() => {
+    delete window._satellite;
+  });
+
+  it('should wait for _satellite to become available and then succeed', async () => {
+    delete window._satellite;
+    setTimeout(() => {
+      window._satellite = {
+        track: (event, options) => {
+          if (typeof options.done === 'function') setTimeout(() => options.done(null, null), 0);
+        },
+      };
+    }, 50);
+    const result = await getExperimentData(['acom_unity_acrobat_compress-pdf']);
+    expect(result).to.equal(null);
+  });
+
+  it('should reject when _satellite is not available within timeout', async () => {
+    delete window._satellite;
+    const clock = sinon.useFakeTimers();
+    try {
+      const promise = getExperimentData(['acom_unity_acrobat_compress-pdf']);
+      await clock.tickAsync(5100);
+      await promise;
+      expect.fail('Should have rejected');
+    } catch (error) {
+      expect(error.message).to.equal('_satellite not available within timeout');
+    } finally {
+      clock.restore();
+    }
   });
 });
 

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -273,11 +273,21 @@ export default class ActionBinder {
     if (this.pageConfigFetched) return;
     this.pageConfigFetched = true;
     const verb = this.workflowCfg.enabledFeatures[0];
+    let pageConfig;
     try {
       const { fetchPageConfig } = await import('../../../scripts/utils.js');
-      const { default: getExperimentData } = await import('../../../utils/experiment-provider.js');
-      const pageConfig = await fetchPageConfig({ product: 'acrobat', verb });
+      pageConfig = await fetchPageConfig({ product: 'acrobat', verb });
       this.pageConfigLocation = pageConfig.location;
+    } catch (error) {
+      await this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, {
+        code: 'warn_fetch_experiment',
+        desc: error.message,
+      });
+      this.acrobatApiConfig = this.getAcrobatApiConfig();
+      return;
+    }
+    try {
+      const { default: getExperimentData } = await import('../../../utils/experiment-provider.js');
       if (pageConfig.config?.target?.enabled) {
         this.experimentData = await getExperimentData(pageConfig.config.target.decisionScopes);
         this.experimentViaPageConfig = true;
@@ -291,6 +301,8 @@ export default class ActionBinder {
         code: 'warn_fetch_experiment',
         desc: error.message,
       });
+      this.pageConfigFetched = false;
+      this.pageConfigPromise = null;
     }
     this.acrobatApiConfig = this.getAcrobatApiConfig();
   }

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -194,7 +194,6 @@ export default class ActionBinder {
     this.initialize();
     this.experimentData = null;
     this.experimentViaPageConfig = false;
-    this.experimentDataPromise = null;
     this.pageConfigLocation = null;
     this.pageConfigFetched = false;
     this.pageConfigPromise = null;
@@ -276,18 +275,16 @@ export default class ActionBinder {
     const verb = this.workflowCfg.enabledFeatures[0];
     try {
       const { fetchPageConfig } = await import('../../../scripts/utils.js');
-      const { default: getExperimentData, getDecisionScopesForVerb } = await import('../../../utils/experiment-provider.js');
+      const { default: getExperimentData } = await import('../../../utils/experiment-provider.js');
       const pageConfig = await fetchPageConfig({ product: 'acrobat', verb });
       this.pageConfigLocation = pageConfig.location;
       if (pageConfig.config?.target?.enabled) {
-        this.experimentDataPromise = getExperimentData(pageConfig.config.target.decisionScopes)
-          .then((data) => { this.experimentData = data; this.experimentViaPageConfig = true; })
-          .catch((error) => this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, { code: 'warn_fetch_experiment', desc: error.message }));
+        this.experimentData = await getExperimentData(pageConfig.config.target.decisionScopes);
+        this.experimentViaPageConfig = true;
       } else if (!this.experimentData && this.workflowCfg.targetCfg?.experimentationOn?.includes(verb)) {
-        this.experimentDataPromise = getDecisionScopesForVerb(verb)
-          .then((decisionScopes) => getExperimentData(decisionScopes))
-          .then((data) => { this.experimentData = data; })
-          .catch((error) => this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, { code: 'warn_fetch_experiment', desc: error.message }));
+        const { getDecisionScopesForVerb } = await import('../../../utils/experiment-provider.js');
+        const decisionScopes = await getDecisionScopesForVerb(verb);
+        this.experimentData = await getExperimentData(decisionScopes);
       }
     } catch (error) {
       await this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, {
@@ -544,7 +541,6 @@ export default class ActionBinder {
       if (this.multiFileValidationFailure) cOpts.payload.feedback = 'uploaderror';
       if (this.showInfoToast) cOpts.payload.feedback = 'nonpdf';
     }
-    if (this.experimentDataPromise) await this.experimentDataPromise;
     if (this.experimentData && (this.experimentViaPageConfig || this.workflowCfg.targetCfg?.experimentationOn?.includes(this.workflowCfg.enabledFeatures[0]))) {
       cOpts.payload.variationId = this.experimentData.variationId;
     }

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -273,21 +273,13 @@ export default class ActionBinder {
     if (this.pageConfigFetched) return;
     this.pageConfigFetched = true;
     const verb = this.workflowCfg.enabledFeatures[0];
+    const isRetry = !!this.pageConfigLocation;
     let pageConfig;
     try {
       const { fetchPageConfig } = await import('../../../scripts/utils.js');
+      const { default: getExperimentData } = await import('../../../utils/experiment-provider.js');
       pageConfig = await fetchPageConfig({ product: 'acrobat', verb });
       this.pageConfigLocation = pageConfig.location;
-    } catch (error) {
-      await this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, {
-        code: 'warn_fetch_experiment',
-        desc: error.message,
-      });
-      this.acrobatApiConfig = this.getAcrobatApiConfig();
-      return;
-    }
-    try {
-      const { default: getExperimentData } = await import('../../../utils/experiment-provider.js');
       if (pageConfig.config?.target?.enabled) {
         this.experimentData = await getExperimentData(pageConfig.config.target.decisionScopes);
         this.experimentViaPageConfig = true;
@@ -297,10 +289,20 @@ export default class ActionBinder {
         this.experimentData = await getExperimentData(decisionScopes);
       }
     } catch (error) {
-      await this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, {
-        code: 'warn_fetch_experiment',
-        desc: error.message,
-      });
+      if (!pageConfig) {
+        await this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, {
+          code: 'warn_fetch_experiment',
+          desc: error.message,
+        });
+        this.acrobatApiConfig = this.getAcrobatApiConfig();
+        return;
+      }
+      if (isRetry) {
+        await this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, {
+          code: 'warn_fetch_experiment',
+          desc: error.message,
+        });
+      }
       this.pageConfigFetched = false;
       this.pageConfigPromise = null;
     }

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -194,6 +194,7 @@ export default class ActionBinder {
     this.initialize();
     this.experimentData = null;
     this.experimentViaPageConfig = false;
+    this.experimentDataPromise = null;
     this.pageConfigLocation = null;
     this.pageConfigFetched = false;
     this.pageConfigPromise = null;
@@ -275,16 +276,18 @@ export default class ActionBinder {
     const verb = this.workflowCfg.enabledFeatures[0];
     try {
       const { fetchPageConfig } = await import('../../../scripts/utils.js');
-      const { default: getExperimentData } = await import('../../../utils/experiment-provider.js');
+      const { default: getExperimentData, getDecisionScopesForVerb } = await import('../../../utils/experiment-provider.js');
       const pageConfig = await fetchPageConfig({ product: 'acrobat', verb });
       this.pageConfigLocation = pageConfig.location;
       if (pageConfig.config?.target?.enabled) {
-        this.experimentData = await getExperimentData(pageConfig.config.target.decisionScopes);
-        this.experimentViaPageConfig = true;
+        this.experimentDataPromise = getExperimentData(pageConfig.config.target.decisionScopes)
+          .then((data) => { this.experimentData = data; this.experimentViaPageConfig = true; })
+          .catch((error) => this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, { code: 'warn_fetch_experiment', desc: error.message }));
       } else if (!this.experimentData && this.workflowCfg.targetCfg?.experimentationOn?.includes(verb)) {
-        const { getDecisionScopesForVerb } = await import('../../../utils/experiment-provider.js');
-        const decisionScopes = await getDecisionScopesForVerb(verb);
-        this.experimentData = await getExperimentData(decisionScopes);
+        this.experimentDataPromise = getDecisionScopesForVerb(verb)
+          .then((decisionScopes) => getExperimentData(decisionScopes))
+          .then((data) => { this.experimentData = data; })
+          .catch((error) => this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, { code: 'warn_fetch_experiment', desc: error.message }));
       }
     } catch (error) {
       await this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, {
@@ -541,6 +544,7 @@ export default class ActionBinder {
       if (this.multiFileValidationFailure) cOpts.payload.feedback = 'uploaderror';
       if (this.showInfoToast) cOpts.payload.feedback = 'nonpdf';
     }
+    if (this.experimentDataPromise) await this.experimentDataPromise;
     if (this.experimentData && (this.experimentViaPageConfig || this.workflowCfg.targetCfg?.experimentationOn?.includes(this.workflowCfg.enabledFeatures[0]))) {
       cOpts.payload.variationId = this.experimentData.variationId;
     }

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -289,14 +289,6 @@ export default class ActionBinder {
         this.experimentData = await getExperimentData(decisionScopes);
       }
     } catch (error) {
-      if (!pageConfig) {
-        await this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, {
-          code: 'warn_fetch_experiment',
-          desc: error.message,
-        });
-        this.acrobatApiConfig = this.getAcrobatApiConfig();
-        return;
-      }
       if (isRetry) {
         await this.dispatchErrorToast('warn_fetch_experiment', null, error.message, true, true, {
           code: 'warn_fetch_experiment',

--- a/unitylibs/utils/experiment-provider.js
+++ b/unitylibs/utils/experiment-provider.js
@@ -14,10 +14,28 @@ export async function getDecisionScopesForVerb(verb) {
   return region ? [`${verbScope}_${region}`, verbScope] : [verbScope];
 }
 
+function waitForSatellite(timeout = 5000) {
+  if (window._satellite) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const interval = setInterval(() => {
+      if (window._satellite) {
+        clearInterval(interval);
+        resolve();
+      } else if (Date.now() - start >= timeout) {
+        clearInterval(interval);
+        reject(new Error('_satellite not available within timeout'));
+      }
+    }, 100);
+  });
+}
+
 export default async function getExperimentData(decisionScopes) {
   if (!decisionScopes || decisionScopes.length === 0) {
     throw new Error('No decision scopes provided for experiment data fetch');
   }
+
+  await waitForSatellite();
 
   return new Promise((resolve, reject) => {
     try {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

## Problem

A race condition existed between `workflow-acrobat`'s page config initialization and Adobe Launch (`_satellite`) not being ready at page load. When the unity block initialized, `ensurePageConfig` was fired fire-and-forget, which fetched page config and immediately called `window._satellite.track(...)` to retrieve Target experiment data. Since `_satellite` loads asynchronously, this call would throw a `TypeError` if Launch hadn't initialized yet. The error was caught and swallowed, leaving `experimentData` permanently `null` for that session because `pageConfigFetched = true` was already set, preventing any retry when the user actually uploaded a file.

## Changes

### `unitylibs/utils/experiment-provider.js`
- Added `waitForSatellite()`  polls `window._satellite` every 100ms (up to 5 seconds) before invoking `_satellite.track(...)`
- Resolves immediately if `_satellite` is already present, rejects with a clear error on timeout
- Handles the common case where Launch initializes within a few seconds of page load

### `unitylibs/core/workflow/workflow-acrobat/action-binder.js`
- Refactored `ensurePageConfig` to handle the edge case where `_satellite` takes longer than 5 seconds or fails for other reasons
- On `getExperimentData` failure: reset `pageConfigFetched = false` and `pageConfigPromise = null` so the existing `|| this.ensurePageConfig()` guard in `handleFileUpload` naturally triggers a fresh attempt when the user uploads
- Added `const isRetry = !!this.pageConfigLocation` to detect first attempt vs user-triggered retry error is only dispatched to Splunk on retry, suppressing noise from the recoverable first-attempt failure
- `fetchPageConfig` catches all errors internally and always returns `{}`, so the catch block in `ensurePageConfig` is only ever reached via `getExperimentData` failure. Error is only dispatched to Splunk on retry (`isRetry`) since the first attempt failure is expected `_satellite` may not be loaded yet at page load. Flags are reset on failure to allow `ensurePageConfig` to be retried naturally when the user uploads a file.

### `test/utils/experiment-provider.test.js` / `test/core/workflow/workflow-acrobat/action-binder.test.js`
- Added 9 unit tests covering `waitForSatellite` polling and timeout, `ensurePageConfig` guard, flag reset without Splunk dispatch on first failure, flag reset with Splunk dispatch on retry, and success paths via both `pageConfig.config.target` and `targetCfg.experimentationOn`

## Behavior After Fix

| Scenario | Outcome |
|---|---|
| `_satellite` ready before page config completes | Experiment data fetched at page load, no retry needed |
| `_satellite` not ready within 5s | Silent failure at page load, retry triggered automatically when user uploads |
| Retry also fails | Error dispatched to Splunk, resets again for next upload attempt |


## Test plan
- [ ] Verify experiment data is correctly fetched on pages where `_satellite` loads before user interaction (happy path)
- [ ] Verify no visible error toast appears to users when experiment data fetch fails at page load
- [ ] Verify file upload works correctly when `_satellite` is delayed past the 5s timeout
- [ ] Verify `warn_fetch_experiment` Splunk entry is logged only on retry failure, not on initial page load failure

Resolves: [MWPW-199606](https://jira.corp.adobe.com/browse/MWPW-199606)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.live/acrobat/online/split-pdf?unitylibs=stage
- After: https://main--da-dc--adobecom.aem.live/acrobat/online/split-pdf?unitylibs=page-config
