### PR TITLE
Progress bar is not filled till the end even on 100% for acrobat

### DIFF
--- a/test/core/workflow/workflow-acrobat/action-binder.test.js
+++ b/test/core/workflow/workflow-acrobat/action-binder.test.js
@@ -1597,6 +1597,7 @@ describe('ActionBinder', () => {
         const existingTransitionScreen = {
           splashScreenEl: splashLayer,
           LOADER_LIMIT: 95,
+          clearProgressBarHandler: sinon.stub(),
           updateProgressBar: sinon.stub(),
           showSplashScreen: sinon.stub().resolves(),
         };
@@ -1605,6 +1606,7 @@ describe('ActionBinder', () => {
         expect(actionBinder.transitionScreen).to.equal(existingTransitionScreen);
         expect(actionBinder.LOADER_LIMIT).to.equal(100);
         expect(existingTransitionScreen.LOADER_LIMIT).to.equal(100);
+        expect(existingTransitionScreen.clearProgressBarHandler.calledOnce).to.be.true;
         expect(existingTransitionScreen.updateProgressBar.calledOnceWith(splashLayer, 100)).to.be.true;
       });
     });

--- a/test/core/workflow/workflow-acrobat/upload-handler.test.js
+++ b/test/core/workflow/workflow-acrobat/upload-handler.test.js
@@ -828,6 +828,16 @@ describe('UploadHandler', () => {
     });
   });
 
+  describe('initSplashScreen', () => {
+    it('should sync the active transition screen on the action binder', async () => {
+      uploadHandler.initSplashScreen.restore();
+      const { setUnityLibs } = await import('../../../../unitylibs/scripts/utils.js');
+      setUnityLibs('../../../../unitylibs');
+      await uploadHandler.initSplashScreen();
+      expect(mockActionBinder.transitionScreen).to.equal(uploadHandler.transitionScreen);
+    });
+  });
+
   describe('multiFileGuestUpload', () => {
     beforeEach(() => {
       sinon.restore();

--- a/test/unitylibs/scripts/transition-screen.test.js
+++ b/test/unitylibs/scripts/transition-screen.test.js
@@ -33,6 +33,32 @@ describe('TransitionScreen', () => {
       expect(fill.style.width).to.equal('42%');
       expect(status.textContent).to.equal('42%');
     });
+
+    it('should fill to 100% even when LOADER_LIMIT is 95', () => {
+      splashScreenEl.innerHTML = `
+        <div class="spectrum-ProgressBar" value="95" aria-valuenow="95"></div>
+        <div class="spectrum-ProgressBar-percentage">95%</div>
+        <div class="spectrum-ProgressBar-fill" style="width: 95%"></div>
+        <div id="progress-status"></div>
+      `;
+      screen.updateProgressBar(splashScreenEl, 100);
+      const fill = splashScreenEl.querySelector('.spectrum-ProgressBar-fill');
+      expect(splashScreenEl.querySelector('.spectrum-ProgressBar').getAttribute('value')).to.equal('100');
+      expect(splashScreenEl.querySelector('.spectrum-ProgressBar-percentage').innerHTML).to.equal('100%');
+      expect(fill.style.width).to.equal('100%');
+    });
+
+    it('should not decrease progress after reaching 100%', () => {
+      splashScreenEl.innerHTML = `
+        <div class="spectrum-ProgressBar" value="100" aria-valuenow="100"></div>
+        <div class="spectrum-ProgressBar-percentage">100%</div>
+        <div class="spectrum-ProgressBar-fill" style="width: 100%"></div>
+        <div id="progress-status"></div>
+      `;
+      screen.updateProgressBar(splashScreenEl, 95);
+      expect(splashScreenEl.querySelector('.spectrum-ProgressBar').getAttribute('value')).to.equal('100');
+      expect(splashScreenEl.querySelector('.spectrum-ProgressBar-fill').style.width).to.equal('100%');
+    });
   });
 
   describe('createProgressBar', () => {

--- a/unitylibs/core/workflow/workflow-acrobat/action-binder.js
+++ b/unitylibs/core/workflow/workflow-acrobat/action-binder.js
@@ -737,6 +737,7 @@ export default class ActionBinder {
     }
     this.LOADER_LIMIT = 100;
     this.transitionScreen.LOADER_LIMIT = 100;
+    this.transitionScreen.clearProgressBarHandler();
     const splashLayer = this.transitionScreen.splashScreenEl;
     if (this.isDirectUploadVerb(this.filesData?.size)) await this.runProgressBarUpdate(splashLayer);
     else this.transitionScreen.updateProgressBar(splashLayer, 100);

--- a/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
+++ b/unitylibs/core/workflow/workflow-acrobat/upload-handler.js
@@ -651,6 +651,7 @@ export default class UploadHandler {
   async initSplashScreen() {
     const { default: TransitionScreen } = await import(`${getUnityLibs()}/scripts/transition-screen.js`);
     this.transitionScreen = new TransitionScreen(this.actionBinder.transitionScreen.splashScreenEl, this.actionBinder.initActionListeners, this.actionBinder.LOADER_LIMIT, this.actionBinder.workflowCfg);
+    this.actionBinder.transitionScreen = this.transitionScreen;
   }
 
   async showSplashScreen(displayOn = false) {

--- a/unitylibs/scripts/transition-screen.js
+++ b/unitylibs/scripts/transition-screen.js
@@ -43,12 +43,22 @@ export default class TransitionScreen {
   updateProgressBar(layer, percentage) {
     if (!layer) return;
     if (!this.progressText && TransitionScreen.lastProgressText) this.progressText = TransitionScreen.lastProgressText;
-    const p = Math.min(percentage, this.LOADER_LIMIT);
+    const current = parseInt(layer.querySelector('.spectrum-ProgressBar')?.getAttribute('value'), 10) || 0;
+    const p = percentage >= 100 ? 100 : Math.min(percentage, this.LOADER_LIMIT);
+    if (current >= 100 && p < 100) return;
     const spb = layer.querySelector('.spectrum-ProgressBar');
+    const fill = layer.querySelector('.spectrum-ProgressBar-fill');
     spb?.setAttribute('value', p);
     spb?.setAttribute('aria-valuenow', p);
     layer.querySelector('.spectrum-ProgressBar-percentage').innerHTML = `${p}%`;
-    layer.querySelector('.spectrum-ProgressBar-fill').style.width = `${p}%`;
+    if (fill) {
+      if (p >= 100) fill.style.transition = 'none';
+      fill.style.width = `${p}%`;
+      if (p >= 100) {
+        fill.offsetWidth;
+        fill.style.removeProperty('transition');
+      }
+    }
     const status = layer.querySelector('#progress-status');
     const newStatus = (this.progressText && this.progressText.trim() !== '')
       ? this.progressText.replace('%', `${p}%`)
@@ -87,7 +97,7 @@ export default class TransitionScreen {
       this.progressBarTimeoutId = null;
       if (generation !== this.progressBarGeneration) return;
       const v = initialize ? 0 : parseInt(progressBar.getAttribute('value'), 10);
-      if (v === 100) return;
+      if (v >= 100) return;
       this.updateProgressBar(s, v + newI);
       this.progressBarHandler(s, newDelay, newI);
     }, newDelay);


### PR DESCRIPTION
RC: 

1. Multiple TransitionScreen instances shared the same splash DOM — loadTransitionScreen(), upload-handler.initSplashScreen(), and continueInApp() each created their own instance. Auto-progress timers are per-instance, so orphaned timers from earlier instances could keep updating the bar after the final 100% state was set.
2. Label vs fill mismatch — the percentage text updated instantly, but the fill used a 1s CSS width transition, while redirect happened after only 500ms, so the bar often looked incomplete at redirect time.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.live/acrobat/online/sign-pdf?unitylibs=stage
- After: https://main--da-dc--adobecom.aem.live/acrobat/online/sign-pdf?unitylibs=fastfollows3
