### PR TITLE
[MWPW-199559] Focus indicator lacks 3 to 1 contrast ratio

### DIFF
--- a/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.css
+++ b/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.css
@@ -219,7 +219,7 @@
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn:focus {
-  outline: 2px solid #005FCC;
+  outline: 2px solid #0050A8;
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn .btn-ico {

--- a/unitylibs/core/widgets/prompt-bar/prompt-bar.css
+++ b/unitylibs/core/widgets/prompt-bar/prompt-bar.css
@@ -565,7 +565,7 @@
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn:focus {
-  outline: 2px solid #005FCC;
+  outline: 2px solid #0050A8;
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn .btn-ico {


### PR DESCRIPTION
[MWPW-199559] Focus indicator lacks 3 to 1 contrast ratio


Resolves: [MWPW-199559](https://jira.corp.adobe.com/browse/MWPW-199559)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/firefly/features/ai-art-generator?unitylibs=stage
- After:         1. https://main--da-cc--adobecom.aem.page/products/firefly/features/ai-face-generator?unitylibs=mwpw-199559
        2. https://main--da-cc--adobecom.aem.page/products/firefly/features/ai-art-generator?unitylibs=mwpw-199559
