### PR TITLE
MWPW-199559 - Fix focus indicator contrast on Generate button

### DIFF
--- a/unitylibs/core/widgets/prompt-bar-audio/prompt-bar-audio.css
+++ b/unitylibs/core/widgets/prompt-bar-audio/prompt-bar-audio.css
@@ -621,7 +621,7 @@
 }
 
 .unity-prompt-bar-audio.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn:focus {
-  outline: 2px solid #005fcc;
+  outline: 2px solid #0050a8;
 }
 
 .unity-prompt-bar-audio.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn .btn-ico {

--- a/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.css
+++ b/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.css
@@ -219,7 +219,7 @@
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn:focus {
-  outline: 2px solid #005FCC;
+  outline: 2px solid #0050A8;
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn .btn-ico {

--- a/unitylibs/core/widgets/prompt-bar/prompt-bar.css
+++ b/unitylibs/core/widgets/prompt-bar/prompt-bar.css
@@ -565,7 +565,7 @@
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn:focus {
-  outline: 2px solid #005FCC;
+  outline: 2px solid #0050A8;
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn .btn-ico {

--- a/unitylibs/core/workflow/workflow-ai/widget.css
+++ b/unitylibs/core/workflow/workflow-ai/widget.css
@@ -207,7 +207,7 @@
   align-items: center;
 }
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn:focus {
-  outline: 2px solid #005FCC;
+  outline: 2px solid #0050A8;
 }
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn .btn-ico {
   display: flex;


### PR DESCRIPTION
## Summary
- Focus-visible outline on `.unity-act-btn` (Firefly Generate button and related widgets) fails WCAG 1.4.11 Non-text Contrast at 2.71:1
- Change outline color from #005FCC to #0050A8 (3.52:1), confirmed by design (Jordan Schilling) in the ticket thread
- Applied consistently across prompt-bar, prompt-bar-style, prompt-bar-audio, and workflow-ai (same shared rule pattern)

## Test plan
- [ ] Verify focus ring renders correctly on Generate button across all 4 affected widgets
- [ ] Re-run contrast check (Deque/axe or manual) to confirm ≥3:1 against #AEAFAE
- [ ] Visual regression check — no layout/size change, only outline color

MWPW-199559