### PR TITLE
MWPW-200684 - Fix focus indicator contrast on Generate button

### DIFF
--- a/unitylibs/core/widgets/prompt-bar-audio/prompt-bar-audio.css
+++ b/unitylibs/core/widgets/prompt-bar-audio/prompt-bar-audio.css
@@ -621,7 +621,7 @@
 }
 
 .unity-prompt-bar-audio.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn:focus {
-  outline: 2px solid #005fcc;
+  outline: 2px solid #0050A8;
 }
 
 .unity-prompt-bar-audio.unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn .btn-ico {

--- a/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.css
+++ b/unitylibs/core/widgets/prompt-bar-style/prompt-bar-style.css
@@ -219,7 +219,7 @@
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn:focus {
-  outline: 2px solid #005FCC;
+  outline: 2px solid #0050A8;
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn .btn-ico {

--- a/unitylibs/core/widgets/prompt-bar/prompt-bar.css
+++ b/unitylibs/core/widgets/prompt-bar/prompt-bar.css
@@ -565,7 +565,7 @@
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn:focus {
-  outline: 2px solid #005FCC;
+  outline: 2px solid #0050A8;
 }
 
 .unity-enabled .interactive-area .ex-unity-wrap .ex-unity-widget .act-wrap .unity-act-btn .btn-ico {


### PR DESCRIPTION
## Summary
- Fixes WCAG 1.4.11 (Non-text Contrast) failure: the `:focus` outline on the Firefly "Generate" button (`.unity-act-btn.gen-btn`) was `#005FCC` against an adjacent `#AEAFAE` background, measuring 2.72:1 (fails the 3:1 minimum).
- Changes the outline color to `#0050A8` (3.52:1, confirmed by design in the ticket's comment thread) across all three prompt-bar widget variants that share this rule: `prompt-bar.css`, `prompt-bar-style.css`, `prompt-bar-audio.css`.
- `workflow-ai/widget.css` has an identically-named selector but is a different product (Illustrator, not Firefly) and was intentionally left untouched.

Jira: https://jira.corp.adobe.com/browse/MWPW-200684

## Test plan
- [ ] Verify keyboard focus on the Generate button on the Firefly AI Painting page shows the new outline color
- [ ] Confirm contrast ratio >= 3:1 with a contrast-checking tool
- [ ] `npm run lint:css` — no new errors introduced (verified: lint issue counts unchanged before/after on all 3 files)